### PR TITLE
GLFWwindow is a struct, not a class

### DIFF
--- a/lib/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/lib/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -25,7 +25,7 @@
 #include <sofa/gl/DrawToolGL.h>
 #include <SofaBaseVisual/BaseCamera.h>
 
-class GLFWwindow;
+struct GLFWwindow;
 
 namespace sofa::glfw
 {

--- a/lib/src/SofaGLFW/SofaGLFWWindow.h
+++ b/lib/src/SofaGLFW/SofaGLFWWindow.h
@@ -24,7 +24,7 @@
 #include <sofa/simulation/fwd.h>
 #include <SofaBaseVisual/BaseCamera.h>
 
-class GLFWwindow;
+struct GLFWwindow;
 
 namespace sofa::glfw
 {


### PR DESCRIPTION
`GLFWwindow` is declared as a struct, not a class. It must use the same declaration in its forward declaration.