### PR TITLE
[BaseGUI] Add check on root when createwindow()

### DIFF
--- a/lib/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/lib/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -130,6 +130,12 @@ bool SofaGLFWBaseGUI::createWindow(int width, int height, const char* title, boo
 {
     imgui::imguiInit();
 
+    if (m_groot == nullptr)
+    {
+        msg_error("SofaGLFWBaseGUI") << "No simulation root has been defined. Quitting.";
+        return false;
+    }
+
     GLFWwindow* glfwWindow = nullptr;
     if (fullscreenAtStartup)
     {


### PR DESCRIPTION
Encountered the problem 'cause I did not set the root and just got a segfault without any info 🤫