### PR TITLE
Change the selected monitor when toggling fullscreen to the current one

### DIFF
--- a/lib/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/lib/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -37,6 +37,8 @@
 
 #include <SofaGLFW/SofaGLFWImgui.h>
 
+#include <algorithm>
+
 namespace sofa::glfw
 {
 
@@ -190,42 +192,39 @@ void SofaGLFWBaseGUI::destroyWindow()
 
 GLFWmonitor* SofaGLFWBaseGUI::getCurrentMonitor(GLFWwindow *glfwWindow)
 {
-    auto mini = [](int x, int y){ return x < y ? x : y; };
-    auto maxi = [](int x, int y){ return x > y ? x : y; };
-
-    int num_monitors, i;
-    int wx, wy, ww, wh;
-    int mx, my, mw, mh;
-    int overlap, best_overlap;
-    GLFWmonitor *best_monitor;
+    int monitorsCount, i;
+    int windowsX, windowsY, windowsWidth, windowsHeight;
+    int monitorX, monitorY, monitorWidth, monitorHeight;
+    int overlap, bestOverlap;
+    GLFWmonitor *bestMonitor;
     GLFWmonitor **monitors;
     const GLFWvidmode *mode;
 
-    best_overlap = 0;
-    best_monitor = nullptr;
+    bestOverlap = 0;
+    bestMonitor = nullptr;
 
-    glfwGetWindowPos(glfwWindow, &wx, &wy);
-    glfwGetWindowSize(glfwWindow, &ww, &wh);
-    monitors = glfwGetMonitors(&num_monitors);
+    glfwGetWindowPos(glfwWindow, &windowsX, &windowsY);
+    glfwGetWindowSize(glfwWindow, &windowsWidth, &windowsHeight);
+    monitors = glfwGetMonitors(&monitorsCount);
 
-    for (i=0; i < num_monitors; i++)
+    for (i=0; i<monitorsCount; i++)
     {
         mode = glfwGetVideoMode(monitors[i]);
-        glfwGetMonitorPos(monitors[i], &mx, &my);
-        mw = mode->width;
-        mh = mode->height;
+        glfwGetMonitorPos(monitors[i], &monitorX, &monitorY);
+        monitorWidth = mode->width;
+        monitorHeight = mode->height;
 
-        overlap = maxi(0, mini(wx + ww, mx + mw) - maxi(wx, mx)) *
-                  maxi(0, mini(wy + wh, my + mh) - maxi(wy, my));
+        overlap = std::max(0, std::min(windowsX + windowsWidth, monitorX + monitorWidth) - std::max(windowsX, monitorX)) *
+                  std::max(0, std::min(windowsY + windowsHeight, monitorY + monitorHeight) - std::max(windowsY, monitorY));
 
-        if (best_overlap < overlap)
+        if (bestOverlap < overlap)
         {
-            best_overlap = overlap;
-            best_monitor = monitors[i];
+            bestOverlap = overlap;
+            bestMonitor = monitors[i];
         }
     }
 
-    return best_monitor;
+    return bestMonitor;
 }
 
 

--- a/lib/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/lib/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -188,6 +188,46 @@ void SofaGLFWBaseGUI::destroyWindow()
 {
 }
 
+GLFWmonitor* SofaGLFWBaseGUI::getCurrentMonitor(GLFWwindow *glfwWindow)
+{
+    auto mini = [](int x, int y){ return x < y ? x : y; };
+    auto maxi = [](int x, int y){ return x > y ? x : y; };
+
+    int num_monitors, i;
+    int wx, wy, ww, wh;
+    int mx, my, mw, mh;
+    int overlap, best_overlap;
+    GLFWmonitor *best_monitor;
+    GLFWmonitor **monitors;
+    const GLFWvidmode *mode;
+
+    best_overlap = 0;
+    best_monitor = nullptr;
+
+    glfwGetWindowPos(glfwWindow, &wx, &wy);
+    glfwGetWindowSize(glfwWindow, &ww, &wh);
+    monitors = glfwGetMonitors(&num_monitors);
+
+    for (i=0; i < num_monitors; i++)
+    {
+        mode = glfwGetVideoMode(monitors[i]);
+        glfwGetMonitorPos(monitors[i], &mx, &my);
+        mw = mode->width;
+        mh = mode->height;
+
+        overlap = maxi(0, mini(wx + ww, mx + mw) - maxi(wx, mx)) *
+                  maxi(0, mini(wy + wh, my + mh) - maxi(wy, my));
+
+        if (best_overlap < overlap)
+        {
+            best_overlap = overlap;
+            best_monitor = monitors[i];
+        }
+    }
+
+    return best_monitor;
+}
+
 
 bool SofaGLFWBaseGUI::isFullScreen(GLFWwindow* glfwWindow) const
 {
@@ -215,10 +255,10 @@ void SofaGLFWBaseGUI::switchFullScreen(GLFWwindow* glfwWindow, unsigned int /* s
             glfwGetWindowPos(glfwWindow, &m_lastWindowPositionX, &m_lastWindowPositionY);
             glfwGetWindowSize(glfwWindow, &m_lastWindowWidth, &m_lastWindowHeight);
 
-            GLFWmonitor* primaryMonitor = glfwGetPrimaryMonitor();
-            const GLFWvidmode* mode = glfwGetVideoMode(primaryMonitor);
+            GLFWmonitor* monitor = getCurrentMonitor(glfwWindow);
+            const GLFWvidmode* mode = glfwGetVideoMode(monitor);
 
-            glfwSetWindowMonitor(glfwWindow, primaryMonitor, 0, 0, mode->width, mode->height, GLFW_DONT_CARE);
+            glfwSetWindowMonitor(glfwWindow, monitor, 0, 0, mode->width, mode->height, GLFW_DONT_CARE);
         }
         else
         {

--- a/lib/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/lib/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -27,6 +27,7 @@
 #include <sofa/simulation/Node.h>
 
 struct GLFWwindow;
+struct GLFWmonitor;
 
 namespace sofa::glfw
 {
@@ -55,6 +56,8 @@ public:
     void setWindowWidth(int width) { m_windowWidth = width; }
     int getWindowHeight() const { return m_windowHeight; }
     void setWindowHeight(int height) { m_windowHeight = height; }
+
+    GLFWmonitor* getCurrentMonitor(GLFWwindow *window);
 
     bool isFullScreen(GLFWwindow* glfwWindow = nullptr) const;
     void switchFullScreen(GLFWwindow* glfwWindow = nullptr, unsigned int /* screenID */ = 0);


### PR DESCRIPTION
Currently, when toggling to fullscreen, the fullscreen happens on the primary monitor. This may not be the desired behavior when working with multiple monitors. I added a method to the `SofaGLFWBaseGUI` to retrieve the monitor on which the current window is. The solution was taken from this [question](https://stackoverflow.com/questions/21421074/how-to-create-a-full-screen-window-on-the-current-monitor-with-glfw).