### PR TITLE
Remove need of the (soon-to-be deprecated) module SofaBase

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.h
@@ -25,6 +25,8 @@
 #include <SofaGLFW/SofaGLFWBaseGUI.h>
 #include <sofa/gui/BaseGUI.h>
 
+#include <SofaGraphComponent/ViewerSetting.h>
+
 namespace sofaglfw
 {
 

--- a/exe/Main.cpp
+++ b/exe/Main.cpp
@@ -35,8 +35,6 @@
 #include <SofaGraphComponent/ViewerSetting.h>
 #include <SofaBaseVisual/BackgroundSetting.h>
 
-#include <SofaBase/initSofaBase.h>
-
 #include <sofa/helper/system/PluginManager.h>
 
 int main(int argc, char** argv)
@@ -67,10 +65,7 @@ int main(int argc, char** argv)
 
     sofa::helper::BackTrace::autodump();
 
-    sofa::component::initSofaBase();
-
     sofa::simulation::graph::init();
-    sofa::component::initSofaBase();
 
     // create an instance of SofaGLFWGUI
     // linked with the simulation


### PR DESCRIPTION
It was used to forcefully load all SofaBase stuff (especially SofaBaseUtils which had RequiredPlugin)
Now that RequiredPlugin is in the core, it is much less important.
And it will be deprecated for the next release of SOFA anyway