### PR TITLE
Capture logs

### DIFF
--- a/SofaImGui/src/SofaImGui/initSofaImGui.cpp
+++ b/SofaImGui/src/SofaImGui/initSofaImGui.cpp
@@ -24,6 +24,7 @@
 #include <sofa/simulation/Node.h>
 #include <sofa/gui/GUIManager.h>
 #include <SofaImGui/ImGuiGUI.h>
+#include <sofa/helper/logging/LoggingMessageHandler.h>
 
 namespace sofaimgui
 {
@@ -43,6 +44,9 @@ void initExternalModule()
     if (first)
     {
         first = false;
+
+        sofa::helper::logging::MessageDispatcher::addHandler(&sofa::helper::logging::MainLoggingMessageHandler::getInstance());
+        sofa::helper::logging::MainLoggingMessageHandler::getInstance().activate();
 
         sofa::gui::GUIManager::RegisterGUI("imgui", &sofaimgui::ImGuiGUI::CreateGUI);
     }

--- a/exe/Main.cpp
+++ b/exe/Main.cpp
@@ -61,9 +61,7 @@ int main(int argc, char** argv)
         exit(0);
     }
 
-    sofa::helper::logging::MessageDispatcher::addHandler(&sofa::helper::logging::MainLoggingMessageHandler::getInstance());
     sofa::helper::logging::MessageDispatcher::addHandler(&sofa::helper::logging::MainPerComponentLoggingMessageHandler::getInstance()) ;
-    sofa::helper::logging::MainLoggingMessageHandler::getInstance().activate();
 
     sofa::helper::BackTrace::autodump();
 


### PR DESCRIPTION
The log were displayed only with the runSofaGLFW app, but not with runSofa.

![image](https://user-images.githubusercontent.com/10572752/165904941-29b4647b-54f1-4c27-a16a-5b22d3bbd86e.png)
