### PR TITLE
Fix assertion errors in debug mode (msvc)

### DIFF
--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -990,8 +990,8 @@ void ImGuiGUIEngine::showSceneGraph(sofa::core::sptr<sofa::simulation::Node> gro
                         ImGui::EndTable();
                     }
 
+                    ImGui::EndTabItem();
                 }
-                ImGui::EndTabItem();
 
                 ImGui::EndTabBar();
             }

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -100,7 +100,7 @@ void ImGuiGUIEngine::init()
     pv = ini.GetValue("Style", "theme");
     if (!pv)
     {
-        ini.SetValue("Style", "theme", sofaimgui::defaultStyle.c_str(), "Preset of colors and properties to change the theme of the application");
+        ini.SetValue("Style", "theme", sofaimgui::defaultStyle.c_str(), "# Preset of colors and properties to change the theme of the application");
         SI_Error rc = ini.SaveFile(getAppIniFile().c_str());
         pv = sofaimgui::defaultStyle.c_str();
     }


### PR DESCRIPTION
Assert errors while running in (pure) Debug mode in msvc

 - Last argument of simpleini.SetValue() is a comment and must be prefixed with a '#' or ';'
 - misplaced end of tabitem
