### PR TITLE
Changes to silence CMake warnings with v22.06

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.12)
 
 find_package(Sofa.Config REQUIRED)
 
-sofa_add_plugin(SofaGLFW SofaGLFW)
-sofa_add_plugin(SofaImGui SofaImGui)
-sofa_add_application(exe runSofaGLFW OFF)
+sofa_add_subdirectory(plugin SofaGLFW SofaGLFW)
+sofa_add_subdirectory(plugin SofaImGui SofaImGui)
+sofa_add_subdirectory(application exe runSofaGLFW OFF)


### PR DESCRIPTION
This syntax should be used to avoid CMake warnings with v22.06, more specifically, these ones:

```cmake
CMake Warning at Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake:422 (message):
  Deprecated macro.  Use 'sofa_add_subdirectory(plugin ...)' instead.
Call Stack (most recent call first):
  applications/projects/SofaGLFW/CMakeLists.txt:5 (sofa_add_plugin)


Adding plugin SofaGLFW
-- Install prefix: /home/busb2601/sofa/build/release/v22.06/install
-- Using X11 for window creation
CMake Warning at Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake:422 (message):
  Deprecated macro.  Use 'sofa_add_subdirectory(plugin ...)' instead.
Call Stack (most recent call first):
  applications/projects/SofaGLFW/CMakeLists.txt:6 (sofa_add_plugin)


CMake Warning at Sofa/framework/Config/cmake/SofaMacrosConfigure.cmake:442 (message):
  Deprecated macro.  Use 'sofa_add_subdirectory(application ...)' instead.
Call Stack (most recent call first):
  applications/projects/SofaGLFW/CMakeLists.txt:7 (sofa_add_application)
```

This syntax should also be used in the v22.06 branch.