### PR TITLE
[ImGUI] Add save/restore camera parameters from file

### DIFF
--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -1762,10 +1762,10 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
                     }
                 }
             }
-            ImGui::Separator();
+
+            const std::string viewFileName = baseGUI->getFilename() + VIEW_FILE_EXTENSION;
             if (ImGui::MenuItem(ICON_FA_CAMERA ICON_FA_ARROW_RIGHT"  Save Camera"))
             {
-                std::string viewFileName = baseGUI->getFilename() + VIEW_FILE_EXTENSION;
                 sofa::component::visual::BaseCamera::SPtr camera;
                 groot->get(camera);
                 if (camera)
@@ -1780,10 +1780,10 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
                     }
                 }
             }
-            ImGui::Separator();
+            bool fileExists = sofa::helper::system::FileSystem::exists(viewFileName);
+            ImGui::BeginDisabled(!fileExists);
             if (ImGui::MenuItem(ICON_FA_CAMERA ICON_FA_ARROW_LEFT"  Restore Camera"))
             {
-                std::string viewFileName = baseGUI->getFilename() + VIEW_FILE_EXTENSION;
                 sofa::component::visual::BaseCamera::SPtr camera;
                 groot->get(camera);
                 if (camera)
@@ -1798,6 +1798,8 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
                     }
                 }
             }
+
+            ImGui::EndDisabled();
             ImGui::EndMenu();
         }
         if (ImGui::BeginMenu("Windows"))

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -73,6 +73,8 @@ using namespace sofa;
 namespace sofaimgui
 {
 
+constexpr const char* VIEW_FILE_EXTENSION = ".view";
+
 void ImGuiGUIEngine::init()
 {
     IMGUI_CHECKVERSION();
@@ -1744,7 +1746,7 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
                 baseGUI->switchFullScreen();
             }
             ImGui::Separator();
-            if (ImGui::MenuItem(ICON_FA_CAMERA "  Center Camera"))
+            if (ImGui::MenuItem(ICON_FA_CAMERA ICON_FA_CROSSHAIRS"  Center Camera"))
             {
                 sofa::component::visual::BaseCamera::SPtr camera;
                 groot->get(camera);
@@ -1757,6 +1759,42 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
                     else
                     {
                         msg_error_when(!groot->f_bbox.getValue().isValid(), "GUI") << "Global bounding box is invalid: " << groot->f_bbox.getValue();
+                    }
+                }
+            }
+            ImGui::Separator();
+            if (ImGui::MenuItem(ICON_FA_CAMERA ICON_FA_ARROW_RIGHT"  Save Camera"))
+            {
+                std::string viewFileName = baseGUI->getFilename() + VIEW_FILE_EXTENSION;
+                sofa::component::visual::BaseCamera::SPtr camera;
+                groot->get(camera);
+                if (camera)
+                {
+                    if (camera->exportParametersInFile(viewFileName))
+                    {
+                        msg_info("GUI") << "Current camera parameters have been exported to "<< viewFileName << " .";
+                    }
+                    else
+                    {
+                        msg_error("GUI") << "Could not export camera parameters to " << viewFileName << " .";
+                    }
+                }
+            }
+            ImGui::Separator();
+            if (ImGui::MenuItem(ICON_FA_CAMERA ICON_FA_ARROW_LEFT"  Restore Camera"))
+            {
+                std::string viewFileName = baseGUI->getFilename() + VIEW_FILE_EXTENSION;
+                sofa::component::visual::BaseCamera::SPtr camera;
+                groot->get(camera);
+                if (camera)
+                {
+                    if (camera->importParametersFromFile(viewFileName))
+                    {
+                        msg_info("GUI") << "Current camera parameters have been imported from " << viewFileName << " .";
+                    }
+                    else
+                    {
+                        msg_error("GUI") << "Could not import camera parameters from " << viewFileName << " .";
                     }
                 }
             }


### PR DESCRIPTION
and change (add) icons for "center camera".

![Screenshot 2022-12-14 100948](https://user-images.githubusercontent.com/11028016/207480277-92110036-a70c-48da-85c2-2a701d8dbb4d.png)

Restore camera menu is disabled if the view file does not exist

Question: should the camera be restored (if the .view file is present) at start-up like the other GUIs ?