### PR TITLE
[runSOFAGLFW] add batch mode

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -319,17 +319,18 @@ void SofaGLFWBaseGUI::makeCurrentContext(GLFWwindow* glfwWindow)
     }
 }
 
-void SofaGLFWBaseGUI::runLoop(std::size_t targetNbIterations)
+std::size_t SofaGLFWBaseGUI::runLoop(std::size_t targetNbIterations)
 {
     if (!m_groot)
     {
-        return;
+        return 0;
     }
 
     m_vparams = sofa::core::visual::VisualParams::defaultInstance();
 
     bool running = true;
-    m_currentNbIterations = 0;
+    std::size_t currentNbIterations = 0;
+    std::stringstream tmpStr;
     while (!s_mapWindows.empty() && running)
     {
         // Keep running
@@ -363,9 +364,12 @@ void SofaGLFWBaseGUI::runLoop(std::size_t targetNbIterations)
         }
 
         glfwPollEvents();
-        m_currentNbIterations++;
-        running = (targetNbIterations > 0) ? m_currentNbIterations < targetNbIterations : true;
+
+        currentNbIterations++;
+        running = (targetNbIterations > 0) ? currentNbIterations < targetNbIterations : true;
     }
+
+    return currentNbIterations;
 }
 
 void SofaGLFWBaseGUI::initVisual()

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -319,7 +319,7 @@ void SofaGLFWBaseGUI::makeCurrentContext(GLFWwindow* glfwWindow)
     }
 }
 
-void SofaGLFWBaseGUI::runLoop()
+void SofaGLFWBaseGUI::runLoop(std::size_t targetNbIterations)
 {
     if (!m_groot)
     {
@@ -328,7 +328,9 @@ void SofaGLFWBaseGUI::runLoop()
 
     m_vparams = sofa::core::visual::VisualParams::defaultInstance();
 
-    while (!s_mapWindows.empty())
+    bool running = true;
+    m_currentNbIterations = 0;
+    while (!s_mapWindows.empty() && running)
     {
         // Keep running
         runStep();
@@ -361,6 +363,8 @@ void SofaGLFWBaseGUI::runLoop()
         }
 
         glfwPollEvents();
+        m_currentNbIterations++;
+        running = (targetNbIterations > 0) ? m_currentNbIterations < targetNbIterations : true;
     }
 }
 

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -57,7 +57,7 @@ public:
     bool createWindow(int width, int height, const char* title, bool fullscreenAtStartup = false);
     void destroyWindow();
     void initVisual();
-    void runLoop();
+    void runLoop(std::size_t targetNbIterations = 0);
     void terminate();
 
     int getWindowWidth() const { return m_windowWidth; }
@@ -131,6 +131,7 @@ private:
     int m_lastWindowHeight{ 0 };
     
     std::shared_ptr<sofaglfw::BaseGUIEngine> m_guiEngine;
+    std::size_t m_currentNbIterations{ 0 };
 
 };
 

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -57,7 +57,7 @@ public:
     bool createWindow(int width, int height, const char* title, bool fullscreenAtStartup = false);
     void destroyWindow();
     void initVisual();
-    void runLoop(std::size_t targetNbIterations = 0);
+    std::size_t runLoop(std::size_t targetNbIterations = 0);
     void terminate();
 
     int getWindowWidth() const { return m_windowWidth; }
@@ -131,7 +131,6 @@ private:
     int m_lastWindowHeight{ 0 };
     
     std::shared_ptr<sofaglfw::BaseGUIEngine> m_guiEngine;
-    std::size_t m_currentNbIterations{ 0 };
 
 };
 

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
@@ -109,7 +109,7 @@ void SofaGLFWGUI::setBackgroundImage(const std::string& image)
 
 }
 
-sofa::gui::BaseGUI* SofaGLFWGUI::CreateGUI(const char* name, sofa::simulation::NodeSPtr groot, const char* filename)
+sofa::gui::common::BaseGUI* SofaGLFWGUI::CreateGUI(const char* name, sofa::simulation::NodeSPtr groot, const char* filename)
 {
     SofaGLFWGUI::mGuiName = name;
     auto* gui = new SofaGLFWGUI();

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.h
@@ -23,7 +23,7 @@
 #include <SofaGLFW/config.h>
 
 #include <SofaGLFW/SofaGLFWBaseGUI.h>
-#include <sofa/gui/BaseGUI.h>
+#include <sofa/gui/common/BaseGUI.h>
 
 #include <sofa/component/setting/ViewerSetting.h>
 
@@ -32,7 +32,7 @@ namespace sofaglfw
 
 class SofaGLFWWindow;
 
-class SOFAGLFW_API SofaGLFWGUI : public sofa::gui::BaseGUI
+class SOFAGLFW_API SofaGLFWGUI : public sofa::gui::common::BaseGUI
 {
 public:
     SofaGLFWGUI() = default;
@@ -50,7 +50,7 @@ public:
     void setFullScreen() override;
     void setBackgroundColor(const sofa::type::RGBAColor& color) override;
     void setBackgroundImage(const std::string& image) override;
-    static sofa::gui::BaseGUI* CreateGUI(const char* name, sofa::simulation::NodeSPtr groot, const char* filename);
+    static sofa::gui::common::BaseGUI * CreateGUI(const char* name, sofa::simulation::NodeSPtr groot, const char* filename);
 protected:
     SofaGLFWBaseGUI m_baseGUI;
     bool m_bCreateWithFullScreen{ false };

--- a/SofaImGui/src/SofaImGui/ImGuiGUI.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUI.cpp
@@ -25,7 +25,7 @@
 #include <sofa/simulation/Simulation.h>
 
 #include <SofaImGui/ImGuiGUIEngine.h>
-#include <sofa/gui/BaseGUI.h>
+#include <sofa/gui/common/BaseGUI.h>
 
 #include <memory>
 
@@ -40,7 +40,7 @@ ImGuiGUI::ImGuiGUI()
 }
 
 
-sofa::gui::BaseGUI* ImGuiGUI::CreateGUI(const char* name, sofa::simulation::NodeSPtr groot, const char* filename)
+sofa::gui::common::BaseGUI* ImGuiGUI::CreateGUI(const char* name, sofa::simulation::NodeSPtr groot, const char* filename)
 {
     ImGuiGUI::mGuiName = name;
     auto* gui = new ImGuiGUI();

--- a/SofaImGui/src/SofaImGui/ImGuiGUI.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUI.h
@@ -23,7 +23,6 @@
 
 #include <SofaGLFW/SofaGLFWBaseGUI.h>
 #include <SofaGLFW/SofaGLFWGUI.h>
-#include <sofa/gui/BaseGUI.h>
 
 namespace sofaimgui
 {
@@ -35,7 +34,7 @@ public:
     
     ~ImGuiGUI() override = default;
 
-    static sofa::gui::BaseGUI* CreateGUI(const char* name, sofa::simulation::NodeSPtr groot, const char* filename);
+    static sofa::gui::common::BaseGUI* CreateGUI(const char* name, sofa::simulation::NodeSPtr groot, const char* filename);
 };
 
 } // namespace sofaimgui

--- a/SofaImGui/src/SofaImGui/initSofaImGui.cpp
+++ b/SofaImGui/src/SofaImGui/initSofaImGui.cpp
@@ -22,7 +22,7 @@
 #include <SofaImGui/config.h>
 
 #include <sofa/simulation/Node.h>
-#include <sofa/gui/GUIManager.h>
+#include <sofa/gui/common/GUIManager.h>
 #include <SofaImGui/ImGuiGUI.h>
 #include <sofa/helper/logging/LoggingMessageHandler.h>
 
@@ -48,7 +48,7 @@ void initExternalModule()
         sofa::helper::logging::MessageDispatcher::addHandler(&sofa::helper::logging::MainLoggingMessageHandler::getInstance());
         sofa::helper::logging::MainLoggingMessageHandler::getInstance().activate();
 
-        sofa::gui::GUIManager::RegisterGUI("imgui", &sofaimgui::ImGuiGUI::CreateGUI);
+        sofa::gui::common::GUIManager::RegisterGUI("imgui", &sofaimgui::ImGuiGUI::CreateGUI);
     }
 }
 

--- a/exe/Main.cpp
+++ b/exe/Main.cpp
@@ -51,6 +51,7 @@ int main(int argc, char** argv)
         ("h,help", "print usage")
         ;
 
+    options.parse_positional("file");
     const auto result = options.parse(argc, argv);
 
     if (result.count("help"))

--- a/exe/Main.cpp
+++ b/exe/Main.cpp
@@ -145,7 +145,7 @@ int main(int argc, char** argv)
     }
 
     // Run the main loop
-    std::chrono::steady_clock::time_point currentTime = std::chrono::high_resolution_clock::now();
+    const auto currentTime = std::chrono::steady_clock::now();
     const auto currentNbIterations = glfwGUI.runLoop(targetNbIterations);
 
     const auto totalTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - currentTime).count() / 1000.0;

--- a/exe/Main.cpp
+++ b/exe/Main.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv)
 
 
     std::string fileName = result["file"].as<std::string>();
-    const bool startAnim = result["start"].as<bool>();
+    bool startAnim = result["start"].as<bool>();
 
     fileName = sofa::helper::system::DataRepository.getFile(fileName);
 
@@ -118,12 +118,17 @@ int main(int argc, char** argv)
 
     // create a SofaGLFW window
     glfwGUI.createWindow(resolution[0], resolution[1], "SofaGLFW", isFullScreen);
-    //glfwGUI.createWindow(800, 600, "SofaGLFW2");
 
     sofa::simulation::getSimulation()->init(groot.get());
 
-    auto nbIterations = result["nb_iterations"].as<std::size_t>();
-    if (startAnim || nbIterations > 0)
+    auto targetNbIterations = result["nb_iterations"].as<std::size_t>();
+    if (targetNbIterations > 0)
+    {
+        msg_info("SofaGLFW") << "Computing " << targetNbIterations << " iterations.";
+        startAnim = true;
+    }
+
+    if (startAnim)
         groot->setAnimate(true);
 
     glfwGUI.initVisual();
@@ -141,14 +146,10 @@ int main(int argc, char** argv)
 
     // Run the main loop
     std::chrono::steady_clock::time_point currentTime = std::chrono::high_resolution_clock::now();
-    glfwGUI.runLoop(nbIterations);
+    const auto currentNbIterations = glfwGUI.runLoop(targetNbIterations);
 
-    if (nbIterations > 0)
-    {
-        const auto totalTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - currentTime).count() / 1000.0;
-        msg_info("SofaGLFW") << nbIterations << " iterations done in " << totalTime << " s ( " << ( static_cast<double>(nbIterations) / totalTime) << " FPS)." << msgendl;
-    }
-    
+    const auto totalTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - currentTime).count() / 1000.0;
+    msg_info("SofaGLFW") << currentNbIterations << " iterations done in " << totalTime << " s ( " << ( static_cast<double>(currentNbIterations) / totalTime) << " FPS)." << msgendl;
     
     if (groot != nullptr)
         sofa::simulation::getSimulation()->unload(groot);


### PR DESCRIPTION
Normal batch mode (batchgui) is not running any opengl rendering, so trying to measure graphical performance is impossible.

This PR adds a target number of iterations to run, quit and display the final time (simulation + rendering then)
TODO: doing the same for the "normal" runSofa (where SofaGLFW runs as a BaseGUI)