### PR TITLE
Show warning when trying to use mouse interaction

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -485,7 +485,28 @@ void SofaGLFWBaseGUI::key_callback(GLFWwindow* window, int key, int scancode, in
                     currentGUI->second->setSimulationIsRunning(!currentGUI->second->simulationIsRunning());
                 }
             }
-            break;
+        break;
+        case GLFW_KEY_LEFT_CONTROL:
+        case GLFW_KEY_RIGHT_CONTROL:
+            if (action == GLFW_PRESS)
+            {
+                auto currentGUI = s_mapGUIs.find(window);
+                if (currentGUI != s_mapGUIs.end() && currentGUI->second)
+                {
+                    currentGUI->second->m_isMouseInteractionEnabled = true;
+                    msg_warning("SofaGLFWBaseGUI") << "Mouse interaction is not yet available";
+
+                }
+            }
+            else if (action == GLFW_RELEASE)
+            {
+                auto currentGUI = s_mapGUIs.find(window);
+                if (currentGUI != s_mapGUIs.end() && currentGUI->second)
+                {
+                    currentGUI->second->m_isMouseInteractionEnabled = false;
+                }
+            }
+        break;
         default:
             break;
     }
@@ -499,11 +520,14 @@ void SofaGLFWBaseGUI::cursor_position_callback(GLFWwindow* window, double xpos, 
         if (!currentGUI->second->getGUIEngine()->dispatchMouseEvents())
             return;
     }
-    
-    auto currentSofaWindow = s_mapWindows.find(window);
-    if (currentSofaWindow != s_mapWindows.end() && currentSofaWindow->second)
+
+    if (!currentGUI->second->m_isMouseInteractionEnabled)
     {
-        currentSofaWindow->second->mouseMoveEvent(static_cast<int>(xpos), static_cast<int>(ypos));
+        auto currentSofaWindow = s_mapWindows.find(window);
+        if (currentSofaWindow != s_mapWindows.end() && currentSofaWindow->second)
+        {
+            currentSofaWindow->second->mouseMoveEvent(static_cast<int>(xpos), static_cast<int>(ypos));
+        }
     }
 }
 

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -129,6 +129,8 @@ private:
     int m_lastWindowPositionY{ 0 };
     int m_lastWindowWidth{ 0 };
     int m_lastWindowHeight{ 0 };
+
+    bool m_isMouseInteractionEnabled { false };
     
     std::shared_ptr<sofaglfw::BaseGUIEngine> m_guiEngine;
 


### PR DESCRIPTION
This simply shows a warning when trying to press CTRL + mouse to manipulate an object, as in `runSofa` (qglviewer). It also show the entry point to implement the feature