### PR TITLE
[SofaGLFW] add python3-loadable module

### DIFF
--- a/SofaGLFW/CMakeLists.txt
+++ b/SofaGLFW/CMakeLists.txt
@@ -65,6 +65,11 @@ if(Sofa.GUI.Common_FOUND)
     target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.GUI.Common)
 endif()
 
+find_package(SofaPython3 QUIET)
+if(SofaPython3_FOUND)
+    add_subdirectory(bindings)
+endif()
+
 add_definitions("-DSOFAGLFW_RESOURCES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/resources\"")
 
 sofa_create_package_with_targets(

--- a/SofaGLFW/bindings/CMakeLists.txt
+++ b/SofaGLFW/bindings/CMakeLists.txt
@@ -1,0 +1,20 @@
+project(Bindings_SofaGLFW)
+
+set(SOURCE_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/Module_SofaGLFW.cpp
+)
+
+if (NOT TARGET SofaPython3::Plugin)
+    find_package(SofaPython3 REQUIRED COMPONENTS SofaGLFW Bindings.Sofa)
+endif()
+
+SP3_add_python_module(
+    TARGET       ${PROJECT_NAME}
+    PACKAGE      SofaGLFW
+    MODULE       SofaGLFW
+    DESTINATION  /
+    SOURCES      ${SOURCE_FILES}
+    DEPENDS      SofaPython3::Plugin SofaPython3::Bindings.Sofa SofaGLFW
+
+)
+message("-- SofaPython3 bindings for SofaGLFW will be created.")

--- a/SofaGLFW/bindings/Module_SofaGLFW.cpp
+++ b/SofaGLFW/bindings/Module_SofaGLFW.cpp
@@ -1,0 +1,36 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2021 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#include <pybind11/pybind11.h>
+
+#include <SofaGLFW/init.h>
+
+
+namespace py { using namespace pybind11; }
+
+namespace sofaglfw::python3
+{
+
+PYBIND11_MODULE(SofaGLFW, m)
+{
+    sofaglfw::init();
+}
+
+} // namespace sofaglfw::python3

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
@@ -120,9 +120,12 @@ sofa::gui::common::BaseGUI* SofaGLFWGUI::CreateGUI(const char* name, sofa::simul
     {
         return nullptr;
     }
-
-    gui->setScene(groot, filename);
-
+    
+    if(groot)
+    {
+        gui->setScene(groot, filename);
+    }
+    
     return gui;
 }
 


### PR DESCRIPTION
Basically, allows to do
```python
import SofaGLFW
````

into [sofa]python3 scripts


Needs 
- https://github.com/sofa-framework/sofa-setup-action/pull/8

for the github action to compile successfully
(here is the result with the this branch of the action https://github.com/fredroy/SofaGLFW/actions/runs/6807991167 )