### PR TITLE
Force destruction due to protected destructor in BaseGUI

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -480,6 +480,7 @@ void SofaGLFWBaseGUI::terminate()
         return;
 
     m_guiEngine->terminate();
+    m_guiEngine.reset();
 
     glfwTerminate();
 }


### PR DESCRIPTION
The protected destructor prevented to be called, hence memory leak