### PR TITLE
Explicit call to destructor as expected by BaseGUI design

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
@@ -50,6 +50,7 @@ void SofaGLFWGUI::redraw()
 int SofaGLFWGUI::closeGUI()
 { 
     m_baseGUI.terminate();
+    delete this;
     return 0; 
 }
 


### PR DESCRIPTION
The design of `BaseGUI` is as follow:

- The destructor is protected to prevent it to be called. This is because some GUI framework objets can delete themselves, and we don't want to call the destructor again in this case (especially when on the stack).
- Class derived from `BaseGUI` call `delete this` in `closeGUI()`.

`SofaGLFWGUI::closeGUI()` did not call `delete this` in its `closeGUI` method. Hence we had memory leaks.

Replaces https://github.com/sofa-framework/SofaGLFW/pull/113