### PR TITLE
[ImGUI] Add PIC property when on Fedora

### DIFF
--- a/SofaImGui/CMakeLists.txt
+++ b/SofaImGui/CMakeLists.txt
@@ -122,6 +122,7 @@ set(SOURCE_FILES
 )
 
 
+
 set(IMGUI_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/resources ${imgui_SOURCE_DIR} ${implot_SOURCE_DIR} ${iconfontcppheaders_SOURCE_DIR} ${simpleini_SOURCE_DIR})
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${IMGUI_HEADER_FILES} ${IMGUI_SOURCE_FILES})
@@ -134,6 +135,18 @@ find_package(SofaPython3 QUIET)
 if(SofaPython3_FOUND)
     add_subdirectory(bindings)
 endif()
+
+
+#Findout if it is Fedora
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  file(STRINGS /etc/os-release distro REGEX "^NAME=")
+  string(REGEX REPLACE "NAME=\"(.*)\"" "\\1" distro "${distro}")
+  if(distro STREQUAL "Fedora")
+    set_property(TARGET ${PROJECT_NAME}  PROPERTY POSITION_INDEPENDENT_CODE ON)
+  endif()
+endif()
+
+
 
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}

--- a/SofaImGui/CMakeLists.txt
+++ b/SofaImGui/CMakeLists.txt
@@ -26,6 +26,7 @@ FetchContent_Declare(nfd
         GIT_TAG        d4df2b6ad5420f5300c00f418bf28d86291fa675                # v1.0.0
 )
 FetchContent_MakeAvailable(nfd)
+set_property(TARGET nfd  PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 FetchContent_Declare(ImPlot
         GIT_REPOSITORY https://github.com/epezent/implot
@@ -135,18 +136,6 @@ find_package(SofaPython3 QUIET)
 if(SofaPython3_FOUND)
     add_subdirectory(bindings)
 endif()
-
-
-#Findout if it is Fedora
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  file(STRINGS /etc/os-release distro REGEX "^NAME=")
-  string(REGEX REPLACE "NAME=\"(.*)\"" "\\1" distro "${distro}")
-  if(distro STREQUAL "Fedora")
-    set_property(TARGET ${PROJECT_NAME}  PROPERTY POSITION_INDEPENDENT_CODE ON)
-  endif()
-endif()
-
-
 
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}


### PR DESCRIPTION
Try to fix compilation error on Fedora : 
```
/usr/bin/ld: lib/libnfd.a(nfd_gtk.cpp.o): relocation R_X86_64_32S against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
```