### PR TITLE
remove call to terminate as it is already called by destructor

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
@@ -48,8 +48,7 @@ void SofaGLFWGUI::redraw()
 }
 
 int SofaGLFWGUI::closeGUI()
-{ 
-    m_baseGUI.terminate();
+{
     delete this;
     return 0; 
 }


### PR DESCRIPTION
Calling terminate twice lead to a crash