### PR TITLE
[GLFW, ImGui] Automatically restore camera at startup if a view file is present

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -144,6 +144,22 @@ void SofaGLFWBaseGUI::changeCamera(sofa::component::visual::BaseCamera::SPtr new
     }
 }
 
+void SofaGLFWBaseGUI::restoreCamera(sofa::component::visual::BaseCamera::SPtr camera)
+{
+    if (camera)
+    {
+        const std::string viewFileName = this->getFilename() + std::string(this->getCameraFileExtension());
+        if (camera->importParametersFromFile(viewFileName))
+        {
+            msg_info("GUI") << "Current camera parameters have been imported from " << viewFileName << " .";
+        }
+        else
+        {
+            msg_error("GUI") << "Could not import camera parameters from " << viewFileName << " .";
+        }
+    }
+}
+
 void SofaGLFWBaseGUI::setWindowIcon(GLFWwindow* glfwWindow)
 {
     //STBImage relies on DataRepository to find files: it must be extended with the resource files from this plugin

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -84,6 +84,9 @@ public:
 
     sofa::component::visual::BaseCamera::SPtr findCamera(sofa::simulation::NodeSPtr groot);
     void changeCamera(sofa::component::visual::BaseCamera::SPtr newCamera);
+    void restoreCamera(sofa::component::visual::BaseCamera::SPtr camera);
+    constexpr std::string_view getCameraFileExtension() { return ".view"; }
+    
     void setWindowIcon(GLFWwindow* glfwWindow);
 
     void setGUIEngine(std::shared_ptr<BaseGUIEngine> guiEngine)

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
@@ -68,6 +68,9 @@ void SofaGLFWGUI::setScene(sofa::simulation::NodeSPtr groot, const char* filenam
     this->configureGUI(groot);
 
     m_baseGUI.initVisual();
+
+    // update camera if a sidecar file is present
+    m_baseGUI.restoreCamera(m_baseGUI.findCamera(groot));
 }
 
 sofa::simulation::Node* SofaGLFWGUI::currentSimulation()

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -87,7 +87,6 @@ using namespace sofa;
 
 namespace sofaimgui
 {
-    constexpr const char* VIEW_FILE_EXTENSION = ".view";
 
 ImGuiGUIEngine::ImGuiGUIEngine()
             : winManagerProfiler("profiler.txt"),
@@ -193,6 +192,7 @@ void ImGuiGUIEngine::loadFile(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::core::sp
         camera->fitBoundingBox(groot->f_bbox.getValue().minBBox(), groot->f_bbox.getValue().maxBBox());
         baseGUI->changeCamera(camera);
     }
+
     baseGUI->initVisual();
 }
 
@@ -403,7 +403,7 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
                 }
             }
 
-            const std::string viewFileName = baseGUI->getFilename() + VIEW_FILE_EXTENSION;
+            const std::string viewFileName = baseGUI->getFilename() + std::string(baseGUI->getCameraFileExtension());
             if (ImGui::MenuItem(ICON_FA_CAMERA ICON_FA_ARROW_RIGHT"  Save Camera"))
             {
                 sofa::component::visual::BaseCamera::SPtr camera;
@@ -426,17 +426,7 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
             {
                 sofa::component::visual::BaseCamera::SPtr camera;
                 groot->get(camera);
-                if (camera)
-                {
-                    if (camera->importParametersFromFile(viewFileName))
-                    {
-                        msg_info("GUI") << "Current camera parameters have been imported from " << viewFileName << " .";
-                    }
-                    else
-                    {
-                        msg_error("GUI") << "Could not import camera parameters from " << viewFileName << " .";
-                    }
-                }
+                baseGUI->restoreCamera(camera);
             }
 
             ImGui::EndDisabled();


### PR DESCRIPTION
It is implemented in the Base class so both GUIs does restore the view if a view file is present.