### PR TITLE
[ImGui] Add "Reset View" Option to Restore Default Windows Positions

### DIFF
--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -448,7 +448,7 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
                 }
             }
             ImGui::Separator();
-            if (ImGui::MenuItem(ICON_FA_REFRESH  "  Reset View"))
+            if (ImGui::MenuItem(ICON_FA_REFRESH  "  Reset UI Layout"))
             {
                 resetView(dockspace_id,windowNameSceneGraph,windowNameLog,windowNameViewport);
             }

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -259,7 +259,7 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
 
     if (!*firstRunState.getStatePtr())
     {
-        resetView(dockspace_id,windowNameSceneGraph,windowNameLog,windowNameViewport);
+        resetView(dockspace_id, windowNameSceneGraph, windowNameLog, windowNameViewport);
     }
     ImGui::End();
 
@@ -449,9 +449,9 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
             }
             ImGui::Separator();
             if (ImGui::MenuItem(ICON_FA_REFRESH  "  Reset View"))
-             {
+            {
                 resetView(dockspace_id,windowNameSceneGraph,windowNameLog,windowNameViewport);
-             }
+            }
             ImGui::EndMenu();
         }
         if (ImGui::BeginMenu("Windows"))
@@ -601,7 +601,8 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
         ImGui::RenderPlatformWindowsDefault();
     }
 }
-void ImGuiGUIEngine::resetView(ImGuiID dockspace_id, const char* windowNameSceneGraph, const char *windowNameLog, const char *windowNameViewport) {
+void ImGuiGUIEngine::resetView(ImGuiID dockspace_id, const char* windowNameSceneGraph, const char *windowNameLog, const char *windowNameViewport)
+{
     ImGuiViewport* viewport = ImGui::GetMainViewport();
 
     ImGui::DockBuilderRemoveNode(dockspace_id); // clear any previous layout
@@ -620,6 +621,7 @@ void ImGuiGUIEngine::resetView(ImGuiID dockspace_id, const char* windowNameScene
     winManagerLog.setState(true);
     firstRunState.setState(true);// Mark first run as complete
 }
+
 void ImGuiGUIEngine::beforeDraw(GLFWwindow*)
 {
     glClearColor(0,0,0,1);

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -47,6 +47,7 @@
 #include <backends/imgui_impl_opengl3.h>
 #include <backends/imgui_impl_opengl2.h>
 #include <IconsFontAwesome5.h>
+#include <IconsFontAwesome4.h>
 #include <fa-regular-400.h>
 #include <fa-solid-900.h>
 #include <filesystem>
@@ -258,22 +259,7 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
 
     if (!*firstRunState.getStatePtr())
     {
-        ImGui::DockBuilderRemoveNode(dockspace_id); // clear any previous layout
-        ImGui::DockBuilderAddNode(dockspace_id, ImGuiDockNodeFlags_PassthruCentralNode | ImGuiDockNodeFlags_NoDockingInCentralNode | ImGuiDockNodeFlags_DockSpace);
-        ImGui::DockBuilderSetNodeSize(dockspace_id, viewport->Size);
-
-        auto dock_id_right = ImGui::DockBuilderSplitNode(dockspace_id, ImGuiDir_Right, 0.4f, nullptr, &dockspace_id);
-        ImGui::DockBuilderDockWindow(windowNameSceneGraph, dock_id_right);
-        auto dock_id_down = ImGui::DockBuilderSplitNode(dockspace_id, ImGuiDir_Down, 0.3f, nullptr, &dockspace_id);
-        ImGui::DockBuilderDockWindow(windowNameLog, dock_id_down);
-        ImGui::DockBuilderDockWindow(windowNameViewport, dockspace_id);
-        ImGui::DockBuilderFinish(dockspace_id);
-
-        winManagerViewPort.setState(true);
-        winManagerSceneGraph.setState(true);
-        winManagerLog.setState(true);
-
-        firstRunState.setState(true);// Mark first run as complete
+        resetView(dockspace_id,windowNameSceneGraph,windowNameLog,windowNameViewport);
     }
     ImGui::End();
 
@@ -461,7 +447,11 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
                     image.save(outPath, 90);
                 }
             }
-
+            ImGui::Separator();
+            if (ImGui::MenuItem(ICON_FA_REFRESH  "  Reset View"))
+             {
+                resetView(dockspace_id,windowNameSceneGraph,windowNameLog,windowNameViewport);
+             }
             ImGui::EndMenu();
         }
         if (ImGui::BeginMenu("Windows"))
@@ -611,7 +601,25 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
         ImGui::RenderPlatformWindowsDefault();
     }
 }
+void ImGuiGUIEngine::resetView(ImGuiID dockspace_id, const char* windowNameSceneGraph, const char *windowNameLog, const char *windowNameViewport) {
+    ImGuiViewport* viewport = ImGui::GetMainViewport();
 
+    ImGui::DockBuilderRemoveNode(dockspace_id); // clear any previous layout
+    ImGui::DockBuilderAddNode(dockspace_id, ImGuiDockNodeFlags_PassthruCentralNode | ImGuiDockNodeFlags_NoDockingInCentralNode | ImGuiDockNodeFlags_DockSpace);
+    ImGui::DockBuilderSetNodeSize(dockspace_id, viewport->Size);
+
+    auto dock_id_right = ImGui::DockBuilderSplitNode(dockspace_id, ImGuiDir_Right, 0.4f, nullptr, &dockspace_id);
+    ImGui::DockBuilderDockWindow(windowNameSceneGraph, dock_id_right);
+    auto dock_id_down = ImGui::DockBuilderSplitNode(dockspace_id, ImGuiDir_Down, 0.3f, nullptr, &dockspace_id);
+    ImGui::DockBuilderDockWindow(windowNameLog, dock_id_down);
+    ImGui::DockBuilderDockWindow(windowNameViewport, dockspace_id);
+    ImGui::DockBuilderFinish(dockspace_id);
+
+    winManagerViewPort.setState(true);
+    winManagerSceneGraph.setState(true);
+    winManagerLog.setState(true);
+    firstRunState.setState(true);// Mark first run as complete
+}
 void ImGuiGUIEngine::beforeDraw(GLFWwindow*)
 {
     glClearColor(0,0,0,1);

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -50,7 +50,7 @@ public:
 
     ImGuiGUIEngine() ;
     ~ImGuiGUIEngine() = default;
-    
+
     void init() override;
     void initBackend(GLFWwindow*) override;
     void startFrame(sofaglfw::SofaGLFWBaseGUI*) override;
@@ -68,6 +68,7 @@ protected:
     CSimpleIniA ini;
 
     void loadFile(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::core::sptr<sofa::simulation::Node>& groot, std::string filePathName);
+    void resetView(ImGuiID dockspace_id, const char *windowNameSceneGraph, const char *windowNameLog, const char *windowNameViewport) ;
 
     // WindowState members
     windows::WindowState winManagerProfiler;


### PR DESCRIPTION
When users modify the pinned position of the windows in the interface, they may find it difficult to return to the original default view. This PR introduces a new "Reset View" option in the ImGui menu. Clicking this option will restore the window positions to their default state. The reset action is seamless, preserving all current data and avoiding the need to restart the interface. This enhancement simplifies the process of returning to the initial layout and improves user experience.

The window layout has been customized and is not in its default state. Users might struggle to return to this layout.

![Screenshot from 2024-08-05 17-13-58](https://github.com/user-attachments/assets/3485b7d7-964b-4dac-b794-a737064b813c)

After clicking the "Reset View" option, the window layout has been restored to its default position, making it easy to return to the original view without losing any data.

![Screenshot from 2024-08-05 17-14-11](https://github.com/user-attachments/assets/90f851fc-1929-4ac4-9adc-92d671b78592)

The "Reset View" option:
![Screenshot from 2024-08-05 17-20-35](https://github.com/user-attachments/assets/4e484415-2d8d-432a-9eda-5a4b88d83de2)

