### PR TITLE
MacOS: dont change workding directory when glfwinit()

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -85,6 +85,12 @@ bool SofaGLFWBaseGUI::init(int nbMSAASamples)
 
     setErrorCallback();
 
+    // on macOS, glfwInit change the current working directory...
+    // giving this hint avoids doing the change
+#if defined(__APPLE__)
+    glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE);
+#endif
+
     if (glfwInit() == GLFW_TRUE)
     {
         // defined samples for MSAA


### PR DESCRIPTION
https://github.com/glfw/glfw/issues/174

Solution in the quoted PR has been removed, now a hint has to be given to glfw.

It was changing to the path of the executable
So e.g, for example meshExporter was exporting the files next to the python executable (so /usr/bin... 🙄 )