### PR TITLE
[ImGui, GLFW] Fix crash when quitting

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -127,6 +127,7 @@ private:
 
     inline static std::map<GLFWwindow*, SofaGLFWWindow*> s_mapWindows{};
     inline static std::map<GLFWwindow*, SofaGLFWBaseGUI*> s_mapGUIs{};
+    inline static std::size_t s_numberOfActiveWindows = 0;
 
     bool m_bGlfwIsInitialized{ false };
     bool m_bGlewIsInitialized{ false };

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -50,7 +50,8 @@ void SofaGLFWWindow::close()
 }
 
 
-void SofaGLFWWindow::draw(simulation::NodeSPtr groot, core::visual::VisualParams* vparams){
+void SofaGLFWWindow::draw(simulation::NodeSPtr groot, core::visual::VisualParams* vparams)
+{
     glClearColor(m_backgroundColor.r(), m_backgroundColor.g(), m_backgroundColor.b(), m_backgroundColor.a());
     glClearDepth(1.0);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -65,9 +66,9 @@ void SofaGLFWWindow::draw(simulation::NodeSPtr groot, core::visual::VisualParams
         msg_error("SofaGLFWGUI") << "No camera defined.";
         return;
     }
-
+    
     if (groot->f_bbox.getValue().isValid())
-    {
+    {        
         vparams->sceneBBox() = groot->f_bbox.getValue();
         m_currentCamera->setBoundingBox(vparams->sceneBBox().minBBox(), vparams->sceneBBox().maxBBox());
     }

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -188,7 +188,7 @@ void ImGuiGUIEngine::loadFile(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::core::sp
     if( !groot )
         groot = sofa::simulation::getSimulation()->createNewGraph("");
     baseGUI->setSimulation(groot, filePathName);
-
+    
     sofa::simulation::node::initRoot(groot.get());
     auto camera = baseGUI->findCamera(groot);
     if (camera)
@@ -361,8 +361,8 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
             ImGui::Separator();
             if (ImGui::MenuItem("Exit"))
             {
-                //TODO: brutal exit, need to clean up everything (simulation, window, opengl, imgui etc)
-                exit(EXIT_SUCCESS);
+                this->terminate();
+                return;
             }
             ImGui::EndMenu();
         }


### PR DESCRIPTION
1- it was crashing in glfw/imgui if one quits using `Escape` key (due to erasing value in a map while iterating)
2- clean exit in imgui if one quits using the "exit" menu