### PR TITLE
Feature: Change background (color, texture)

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -81,8 +81,16 @@ public:
 
     bool isFullScreen(GLFWwindow* glfwWindow = nullptr) const;
     void switchFullScreen(GLFWwindow* glfwWindow = nullptr, unsigned int screenID = 0);
-    void setBackgroundColor(const RGBAColor& newColor, unsigned int windowID = 0);
-    virtual void setBackgroundImage(const std::string& imageFileName = "textures/SOFA_logo.bmp", unsigned int windowID = 0);
+    void setWindowBackgroundColor(const RGBAColor& newColor, unsigned int windowID = 0);
+    void setWindowBackgroundImage(const std::string& imageFileName, unsigned int windowID = 0);
+    virtual void setBackgroundColour(float r, float g, float b) override
+    {
+        setWindowBackgroundColor(RGBAColor{r, g, b, 1.0f}, 0);
+    }
+    virtual void setBackgroundImage(std::string imageFileName) override
+    {
+        setWindowBackgroundImage(imageFileName, 0);
+    }
 
     sofa::core::sptr<Node> getRootNode() const;
     bool hasWindow() const { return m_firstWindow != nullptr; }
@@ -149,6 +157,7 @@ private:
     Vec2d m_translatedCursorPos;
     Vec2f m_viewPortPosition;
     Vec2f m_windowPosition;
+    std::size_t m_backgroundID{0};
 
     std::shared_ptr<BaseGUIEngine> m_guiEngine;
 };

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
@@ -114,7 +114,7 @@ void SofaGLFWGUI::setFullScreen()
 
 void SofaGLFWGUI::setBackgroundColor(const sofa::type::RGBAColor& color)
 {
-    m_baseGUI.setBackgroundColor(color);
+    m_baseGUI.setWindowBackgroundColor(color);
 }
 
 void SofaGLFWGUI::setBackgroundImage(const std::string& image)

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -122,6 +122,7 @@ void SofaGLFWWindow::draw(simulation::NodeSPtr groot, core::visual::VisualParams
     vparams->setModelViewMatrix(lastModelviewMatrix);
 
     simulation::node::draw(vparams, groot.get());
+    
 }
 
 void SofaGLFWWindow::setBackgroundColor(const RGBAColor& newColor)
@@ -170,6 +171,10 @@ void SofaGLFWWindow::drawBackgroundImage()
     if(!m_backgrounds.contains(m_currentBackgroundFilename))
         return;
 
+    glPushAttrib(GL_ALL_ATTRIB_BITS);
+    
+    glDisable(GL_LIGHTING);
+    
     const auto& background = m_backgrounds[m_currentBackgroundFilename];
 
     if(!background.image)
@@ -214,6 +219,8 @@ void SofaGLFWWindow::drawBackgroundImage()
     glPopMatrix();
 
     glDisable(GL_TEXTURE_2D);
+    
+    glPopAttrib();
 }
 
 void SofaGLFWWindow::setCamera(component::visual::BaseCamera::SPtr newCamera)

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -36,6 +36,8 @@
 #include <sofa/gl/gl.h>
 #include <sofa/gl/Texture.h>
 
+#include <format>
+
 using namespace sofa;
 namespace sofaglfw
 {

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -36,7 +36,6 @@
 #include <sofa/gl/gl.h>
 #include <sofa/gl/Texture.h>
 
-#include <format>
 #include <ranges>
 
 using namespace sofa;
@@ -147,7 +146,7 @@ void SofaGLFWWindow::setBackgroundImage(const std::string& filename)
             auto* backgroundImage = helper::io::Image::FactoryImage::getInstance()->createObject(extension, backgroundImageFilename);
             if( !backgroundImage )
             {
-                msg_warning("GUI") << std::format("Could not load the file {}", filename);
+                msg_warning("GUI") << "Could not load the file " << filename;
                 return;
             }
             else

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -58,13 +58,10 @@ void SofaGLFWWindow::close()
         m_currentBackgroundTexture = nullptr;
     }
     
-    for(auto& [_, background] : m_backgrounds)
+    for(auto& background : m_backgrounds | std::views::values)
     {
         if(background.texture)
             delete background.texture;
-        // looks like the texture already deleted it..
-//        if(background.image)
-//            delete background.image;
     }
     
     m_backgrounds.clear();
@@ -145,7 +142,7 @@ void SofaGLFWWindow::setBackgroundImage(const std::string& filename)
             const auto backgroundImageFilename = sofa::helper::system::DataRepository.getFile(tempFilename);
             
             std::string extension = sofa::helper::system::SetDirectory::GetExtension(filename.c_str());
-            std::transform(extension.begin(),extension.end(),extension.begin(),::tolower );
+            std::ranges::transform(extension, extension.begin(), ::tolower );
             
             auto* backgroundImage = helper::io::Image::FactoryImage::getInstance()->createObject(extension, backgroundImageFilename);
             if( !backgroundImage )

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -37,6 +37,7 @@
 #include <sofa/gl/Texture.h>
 
 #include <format>
+#include <ranges>
 
 using namespace sofa;
 namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -60,8 +60,7 @@ void SofaGLFWWindow::close()
     
     for(auto& background : m_backgrounds | std::views::values)
     {
-        if(background.texture)
-            delete background.texture;
+        delete background.texture;
     }
     
     m_backgrounds.clear();

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
@@ -28,6 +28,16 @@
 
 struct GLFWwindow;
 
+namespace sofa::helper::io
+{
+class Image;
+}
+
+namespace sofa::gl
+{
+class Texture;
+}
+
 namespace sofaglfw
 {
 
@@ -44,6 +54,8 @@ public:
     void mouseButtonEvent(int button, int action, int mods);
     void scrollEvent(double xoffset, double yoffset);
     void setBackgroundColor(const RGBAColor& newColor);
+    void setBackgroundImage(const std::string& filename);
+    void drawBackgroundImage();
 
     void setCamera(sofa::component::visual::BaseCamera::SPtr newCamera);
     void centerCamera(sofa::simulation::NodeSPtr node, sofa::core::visual::VisualParams* vparams) const;
@@ -58,6 +70,16 @@ private:
     int m_currentXPos{ -1 };
     int m_currentYPos{ -1 };
     RGBAColor m_backgroundColor{ RGBAColor::black() };
+    sofa::gl::Texture* m_currentBackgroundTexture { nullptr };
+    
+    struct Background
+    {
+        sofa::helper::io::Image* image {nullptr};
+        sofa::gl::Texture* texture {nullptr};
+    };
+    
+    std::map<std::string, Background> m_backgrounds;
+    std::string m_currentBackgroundFilename{};
 };
 
 } // namespace sofaglfw

--- a/exe/Main.cpp
+++ b/exe/Main.cpp
@@ -137,10 +137,10 @@ int main(int argc, char** argv)
     groot->get(background, sofa::core::objectmodel::BaseContext::SearchRoot);
     if (background)
     {
-        if (background->image.getValue().empty())
-            glfwGUI.setBackgroundColor(background->color.getValue());
+        if (background->d_image.getValue().empty())
+            glfwGUI.setWindowBackgroundColor(background->d_color.getValue());
         else
-            glfwGUI.setBackgroundImage(background->image.getFullPath());
+            glfwGUI.setWindowBackgroundImage(background->d_image.getFullPath());
     }
 
     // Run the main loop


### PR DESCRIPTION
Like Sofa.Qt, pushing 'B' key will change the background in rotations (texture_black, texture_white, black, white).
and by default  texture_black is used at startup.

- Code is a bit convoluted because of the architecture of BaseGUI and the fact that SofaGLFW wanted to manage more than 1 window (wondering about this now)
- Sofa.Qt was reloading the texture every time it was called ; here we keep in cache if the texture has already been loaded.

As glfw/imgui have the same backend, the feature is available in both GUIs
