### PR TITLE
(Again) Update macos image version to macos14 (arm64 by default) #145 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-2022]
+        os: [ubuntu-22.04, macos-14, windows-2022]
         sofa_branch: [master]
 
     steps:          


### PR DESCRIPTION
https://github.com/sofa-framework/SofaGLFW/pull/145 forgot the second setup