### PR TITLE
Imgui: Support (macOS) HiDPI font scaling

### DIFF
--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -160,9 +160,9 @@ void ImGuiGUIEngine::initBackend(GLFWwindow* glfwWindow)
     }
     if (monitor)
     {
-        float xscale, yscale;
+        float xscale{}, yscale{};
         glfwGetMonitorContentScale(monitor, &xscale, &yscale);
-
+        
         ImGuiIO& io = ImGui::GetIO();
 
         io.Fonts->AddFontFromMemoryCompressedTTF(ROBOTO_MEDIUM_compressed_data, ROBOTO_MEDIUM_compressed_size, 16 * yscale);
@@ -176,7 +176,7 @@ void ImGuiGUIEngine::initBackend(GLFWwindow* glfwWindow)
 
         // restore the global scale stored in the Settings ini file
         const float globalScale = static_cast<float>(ini.GetDoubleValue("Visualization", "globalScale", 1.0));
-        io.FontGlobalScale = globalScale;
+        this->setScale(globalScale, monitor);
     }
 }
 
@@ -593,7 +593,7 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
     /***************************************
      * Settings window
      **************************************/
-    windows::showSettings(windowNameSettings,ini, winManagerSettings);
+    windows::showSettings(windowNameSettings,ini, winManagerSettings, this);
 
     ImGui::Render();
 #if SOFAIMGUI_FORCE_OPENGL2 == 1
@@ -678,6 +678,22 @@ void ImGuiGUIEngine::terminate()
 bool ImGuiGUIEngine::dispatchMouseEvents()
 {
     return !ImGui::GetIO().WantCaptureMouse || isMouseOnViewport;
+}
+
+
+void ImGuiGUIEngine::setScale(double globalScale, GLFWmonitor* monitor)
+{
+    if(!monitor)
+    {
+        monitor = glfwGetPrimaryMonitor();
+    }
+    
+    ImGuiIO& io = ImGui::GetIO();
+    
+    float xscale{}, yscale{};
+    glfwGetMonitorContentScale(monitor, &xscale, &yscale);
+    
+    io.FontGlobalScale = globalScale / yscale;
 }
 
 } //namespace sofaimgui

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -34,6 +34,8 @@
 using windows::WindowState;
 
 struct GLFWwindow;
+struct GLFWmonitor;
+
 namespace sofa::glfw
 {
     class SofaGLFWBaseGUI;
@@ -57,6 +59,9 @@ public:
     void afterDraw() override;
     void terminate() override;
     bool dispatchMouseEvents() override;
+    
+    // apply global scale on the given monitor (if null, it will fetch the main monitor)
+    void setScale(double globalScale, GLFWmonitor* monitor);
 
 protected:
     std::unique_ptr<sofa::gl::FrameBufferObject> m_fbo;

--- a/SofaImGui/src/SofaImGui/windows/Settings.cpp
+++ b/SofaImGui/src/SofaImGui/windows/Settings.cpp
@@ -37,7 +37,8 @@ namespace windows
 
     void showSettings(const char* const& windowNameSettings,
                       CSimpleIniA &ini,
-                      WindowState& winManagerSettings)
+                      WindowState& winManagerSettings,
+                      sofaimgui::ImGuiGUIEngine* engine)
     {
         if (*winManagerSettings.getStatePtr())
         {
@@ -66,16 +67,17 @@ namespace windows
                     ImGui::EndCombo();
                 }
 
-                float globalScale = static_cast<float>(ini.GetDoubleValue("Visualization", "globalScale", 1.0));
+                float iniGlobalScale = static_cast<float>(ini.GetDoubleValue("Visualization", "globalScale", 1.0));
                 {
-                    ImGuiIO& io = ImGui::GetIO();
-                    io.FontGlobalScale = globalScale;
+                    float globalScale = iniGlobalScale;
                     constexpr float MIN_SCALE = 0.3f;
                     constexpr float MAX_SCALE = 2.0f;
-                    ImGui::DragFloat("global scale", &io.FontGlobalScale, 0.005f, MIN_SCALE, MAX_SCALE, "%.2f", ImGuiSliderFlags_AlwaysClamp); // Scale everything
-
-                    ini.SetDoubleValue("Visualization", "globalScale", static_cast<double>(io.FontGlobalScale));
-                    if (std::abs(globalScale - io.FontGlobalScale) > 0.005f)
+                    ImGui::DragFloat("global scale", &globalScale, 0.005f, MIN_SCALE, MAX_SCALE, "%.2f", ImGuiSliderFlags_AlwaysClamp); // Scale everything
+                    
+                    engine->setScale(globalScale, nullptr);
+                    
+                    ini.SetDoubleValue("Visualization", "globalScale", static_cast<double>(globalScale));
+                    if (std::abs(iniGlobalScale - globalScale) > 0.005f)
                     {
                         [[maybe_unused]] SI_Error rc = ini.SaveFile(sofaimgui::AppIniFile::getAppIniFile().c_str());
                     }

--- a/SofaImGui/src/SofaImGui/windows/Settings.h
+++ b/SofaImGui/src/SofaImGui/windows/Settings.h
@@ -24,6 +24,10 @@
 #include <sofa/simulation/Node.h>
 #include "WindowState.h"
 
+namespace sofaimgui
+{
+    class ImGuiGUIEngine;
+}
 
 namespace windows
 {
@@ -34,11 +38,11 @@ namespace windows
          * This function displays settings for configuring the application, such as theme selection, global scale, and viewport settings.
          *
          * @param windowNameSettings The name of the Settings window.
-         * @param isSettingsOpen A reference to a boolean flag indicating if the Settings window is open.
          * @param ini The INI file object containing application settings.
          */
         void showSettings(const char* const& windowNameSettings,
                           CSimpleIniA &ini,
-                          WindowState& winManagerSettings);
+                          WindowState& winManagerSettings,
+                          sofaimgui::ImGuiGUIEngine* engine);
 
 } // namespace sofaimgui


### PR DESCRIPTION
Very simple way to handle HiDPI fonts/icons on macOS system (tested on a macbook pro with 2x scale)
Not tested on Linux or Windows similar mechanisms

And it assumes all windows/monitors shares the same HiDPI scale (true for macOS but I suppose it could be false for Windows or Linux I guess)
