### PR TITLE
Use external dependencies

### DIFF
--- a/SofaGLFW/CMakeLists.txt
+++ b/SofaGLFW/CMakeLists.txt
@@ -14,23 +14,24 @@ include(FetchContent)
 find_package(glfw3 CONFIG QUIET)
 
 if(NOT TARGET glfw)
-  FetchContent_Declare(glfw
-          GIT_REPOSITORY https://github.com/glfw/glfw
-          GIT_TAG        3.3.4
-  )
+    message("glfw3 not found, fetching source code...")
+    FetchContent_Declare(glfw
+            GIT_REPOSITORY https://github.com/glfw/glfw
+            GIT_TAG        3.3.4
+    )
 
-  FetchContent_GetProperties(glfw)
-  if(NOT glfw_POPULATED)
-      FetchContent_Populate(glfw)
+    FetchContent_GetProperties(glfw)
+    if(NOT glfw_POPULATED)
+        FetchContent_Populate(glfw)
 
-      set(GLFW_BUILD_EXAMPLES OFF CACHE INTERNAL "Build the GLFW example programs")
-      set(GLFW_BUILD_TESTS OFF CACHE INTERNAL "Build the GLFW test programs")
-      set(GLFW_BUILD_DOCS OFF CACHE INTERNAL "Build the GLFW documentation")
-      set(GLFW_INSTALL ON CACHE INTERNAL "Generate installation target")
-      set(BUILD_SHARED_LIBS ON CACHE INTERNAL "Build GLFW as a shared library")
+        set(GLFW_BUILD_EXAMPLES OFF CACHE INTERNAL "Build the GLFW example programs")
+        set(GLFW_BUILD_TESTS OFF CACHE INTERNAL "Build the GLFW test programs")
+        set(GLFW_BUILD_DOCS OFF CACHE INTERNAL "Build the GLFW documentation")
+        set(GLFW_INSTALL ON CACHE INTERNAL "Generate installation target")
+        set(BUILD_SHARED_LIBS ON CACHE INTERNAL "Build GLFW as a shared library")
 
-      add_subdirectory(${glfw_SOURCE_DIR} ${glfw_BINARY_DIR})
-  endif()
+        add_subdirectory(${glfw_SOURCE_DIR} ${glfw_BINARY_DIR})
+    endif()
 endif()
 
 set(SOFAGLFW_SOURCE_DIR src/SofaGLFW)

--- a/SofaGLFW/CMakeLists.txt
+++ b/SofaGLFW/CMakeLists.txt
@@ -61,7 +61,7 @@ endif()
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 
 target_link_libraries(${PROJECT_NAME} PUBLIC Sofa.GL Sofa.Simulation.Graph Sofa.Component.Visual)
-target_link_libraries(${PROJECT_NAME} PRIVATE glfw)
+target_link_libraries(${PROJECT_NAME} PUBLIC glfw)
 target_include_directories(${PROJECT_NAME} PUBLIC 
     $<BUILD_INTERFACE:${glfw_SOURCE_DIR}/include>  
     $<INSTALL_INTERFACE:include>

--- a/SofaGLFW/CMakeLists.txt
+++ b/SofaGLFW/CMakeLists.txt
@@ -11,22 +11,26 @@ sofa_find_package(Sofa.GUI.Common QUIET)
 
 include(FetchContent)
 
-FetchContent_Declare(glfw
-        GIT_REPOSITORY https://github.com/glfw/glfw
-        GIT_TAG        3.3.4
-)
+find_package(glfw3 CONFIG QUIET)
 
-FetchContent_GetProperties(glfw)
-if(NOT glfw_POPULATED)
-    FetchContent_Populate(glfw)
+if(NOT TARGET glfw)
+  FetchContent_Declare(glfw
+          GIT_REPOSITORY https://github.com/glfw/glfw
+          GIT_TAG        3.3.4
+  )
 
-    set(GLFW_BUILD_EXAMPLES OFF CACHE INTERNAL "Build the GLFW example programs")
-    set(GLFW_BUILD_TESTS OFF CACHE INTERNAL "Build the GLFW test programs")
-    set(GLFW_BUILD_DOCS OFF CACHE INTERNAL "Build the GLFW documentation")
-    set(GLFW_INSTALL ON CACHE INTERNAL "Generate installation target")
-    set(BUILD_SHARED_LIBS ON CACHE INTERNAL "Build GLFW as a shared library")
+  FetchContent_GetProperties(glfw)
+  if(NOT glfw_POPULATED)
+      FetchContent_Populate(glfw)
 
-    add_subdirectory(${glfw_SOURCE_DIR} ${glfw_BINARY_DIR})
+      set(GLFW_BUILD_EXAMPLES OFF CACHE INTERNAL "Build the GLFW example programs")
+      set(GLFW_BUILD_TESTS OFF CACHE INTERNAL "Build the GLFW test programs")
+      set(GLFW_BUILD_DOCS OFF CACHE INTERNAL "Build the GLFW documentation")
+      set(GLFW_INSTALL ON CACHE INTERNAL "Generate installation target")
+      set(BUILD_SHARED_LIBS ON CACHE INTERNAL "Build GLFW as a shared library")
+
+      add_subdirectory(${glfw_SOURCE_DIR} ${glfw_BINARY_DIR})
+  endif()
 endif()
 
 set(SOFAGLFW_SOURCE_DIR src/SofaGLFW)

--- a/SofaImGui/CMakeLists.txt
+++ b/SofaImGui/CMakeLists.txt
@@ -135,7 +135,7 @@ set(IMGUI_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/resources ${imgui_SOURCE_DIR} $
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${IMGUI_HEADER_FILES} ${IMGUI_SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PRIVATE ${IMGUI_SOURCE_DIR})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaGLFW Sofa.GL.Component.Rendering3D ${CMAKE_DL_LIBS})
-target_link_libraries(${PROJECT_NAME} PRIVATE nfd::nfd glfw)
+target_link_libraries(${PROJECT_NAME} PRIVATE nfd::nfd)
 
 find_package(SofaPython3 QUIET)
 if(SofaPython3_FOUND)

--- a/SofaImGui/CMakeLists.txt
+++ b/SofaImGui/CMakeLists.txt
@@ -21,12 +21,20 @@ FetchContent_Declare(imgui
 )
 FetchContent_MakeAvailable(imgui)
 
-FetchContent_Declare(nfd
-        GIT_REPOSITORY https://github.com/btzy/nativefiledialog-extended
-        GIT_TAG        d4df2b6ad5420f5300c00f418bf28d86291fa675                # v1.0.0
-)
-FetchContent_MakeAvailable(nfd)
-set_property(TARGET nfd  PROPERTY POSITION_INDEPENDENT_CODE ON)
+find_package(nfd CONFIG QUIET)
+
+if(NOT TARGET nfd::nfd)
+    message("nativefiledialog-extended not found, fetching source code...")
+    FetchContent_Declare(nfd
+            GIT_REPOSITORY https://github.com/btzy/nativefiledialog-extended
+            GIT_TAG        d4df2b6ad5420f5300c00f418bf28d86291fa675                # v1.0.0
+    )
+    FetchContent_MakeAvailable(nfd)
+    set_property(TARGET nfd  PROPERTY POSITION_INDEPENDENT_CODE ON)
+    set_target_properties(nfd PROPERTIES LINKER_LANGUAGE CXX)
+    add_library(nfd::nfd ALIAS nfd) # introduced in nfd >= v1.2.1
+endif()
+
 
 FetchContent_Declare(ImPlot
         GIT_REPOSITORY https://github.com/epezent/implot
@@ -98,10 +106,6 @@ set(HEADER_FILES
     ${SOFAIMGUI_SOURCE_DIR}/windows/ViewPort.h
     ${SOFAIMGUI_SOURCE_DIR}/AppIniFile.h
     ${SOFAIMGUI_SOURCE_DIR}/windows/WindowState.h
-
-
-
-
 )
 
 set(SOURCE_FILES
@@ -131,8 +135,7 @@ set(IMGUI_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/resources ${imgui_SOURCE_DIR} $
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES} ${IMGUI_HEADER_FILES} ${IMGUI_SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PRIVATE ${IMGUI_SOURCE_DIR})
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaGLFW Sofa.GL.Component.Rendering3D ${CMAKE_DL_LIBS})
-set_target_properties(nfd PROPERTIES LINKER_LANGUAGE CXX)
-target_link_libraries(${PROJECT_NAME} PRIVATE nfd glfw)
+target_link_libraries(${PROJECT_NAME} PRIVATE nfd::nfd glfw)
 
 find_package(SofaPython3 QUIET)
 if(SofaPython3_FOUND)


### PR DESCRIPTION
This PR adds support for using some of the fetched libraries as available by an external package, so implementing a 'find or fetch' mechanism.
The goal here is to target the libraries that must be shipped otherwise with the plugin, in order to make the SofaGLFW compatible with the conda package manager and keep an available full installation of SOFA with conda (see #152).
Thus the concerned libraries for having at least a runtime package of SofaGLFW are:
- `glfw`, which is already available as a conda package on conda-forge ( https://github.com/conda-forge/glfw-feedstock )
- `nativefiledialog-extended` (or `nfd`), already available as a conda package on our sofa-framework channel ( https://anaconda.org/sofa-framework/nativefiledialog-extended ), and hopefully soon on conda-forge since a PR has been submitted ( https://github.com/conda-forge/staged-recipes/pull/29188 ).

Commit d59c223 fixes a compilation bug on windows due to the lack of exporting link directories of `glfw` for SofaImGui, which occurs when the `glfw` `.lib` file (required for linking on windows) is not in a global directory already included by another lib, as it is the case when compiling under conda.