### PR TITLE
Set dirty outputs when changing a SelectableItem

### DIFF
--- a/SofaImGui/src/SofaImGui/ImGuiDataWidget.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiDataWidget.cpp
@@ -625,6 +625,7 @@ void DataWidget<helper::BaseSelectableItem>::showWidget(
         static_cast<int>(selectableItems->getNumberOfItems())))
     {
         const_cast<helper::BaseSelectableItem*>(selectableItems)->setSelectedId(selectedId);
+        data.setDirtyOutputs();
     }
 }
 


### PR DESCRIPTION
Otherwise, callbacks are not called