### PR TITLE
GUI passes mouse settings to pick handler

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
@@ -139,4 +139,15 @@ sofa::gui::common::BaseGUI* SofaGLFWGUI::CreateGUI(const char* name, sofa::simul
     return gui;
 }
 
+void SofaGLFWGUI::setMouseButtonConfiguration(sofa::component::setting::MouseButtonSetting *setting)
+{
+    if (setting)
+    {
+        if (auto* pickHandler = m_baseGUI.getPickHandler())
+        {
+            pickHandler->changeOperation(setting);
+        }
+    }
+}
+
 } // namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.h
@@ -52,6 +52,7 @@ public:
     void setBackgroundColor(const sofa::type::RGBAColor& color) override;
     void setBackgroundImage(const std::string& image) override;
     static sofa::gui::common::BaseGUI * CreateGUI(const char* name, sofa::simulation::NodeSPtr groot, const char* filename);
+    void setMouseButtonConfiguration(sofa::component::setting::MouseButtonSetting *setting) override;
 protected:
     SofaGLFWBaseGUI m_baseGUI;
     bool m_bCreateWithFullScreen{ false };


### PR DESCRIPTION
Otherwise `MouseButtonSetting` are not taken into account by the GUI (see:
https://github.com/sofa-framework/sofa/blob/21247853054c1f15ca4e3dd9e0ccee0833612af7/Sofa/GUI/Common/src/sofa/gui/common/BaseGUI.cpp#L113