### PR TITLE
[SofaGLFW] Force using x11 platform on Linux

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -92,6 +92,12 @@ bool SofaGLFWBaseGUI::init(int nbMSAASamples)
     glfwInitHint(GLFW_COCOA_CHDIR_RESOURCES, GLFW_FALSE);
 #endif
 
+    // Wayland is not fully supported in GLFW
+    // this will force using X11 on wayland (XWayland)
+#if defined(__linux__)
+    glfwInitHint(GLFW_PLATFORM, GLFW_PLATFORM_X11);
+#endif
+
     if (glfwInit() == GLFW_TRUE)
     {
         // defined samples for MSAA


### PR DESCRIPTION
Using the GUI while being on Linux and Wayland, this happens:
![image](https://github.com/user-attachments/assets/695a9f8d-a422-4676-ba51-9a075d49267c)
spamming quite a lot (at every refresh of the window...)

According to  https://github.com/glfw/glfw/issues/2621 , it is due to some unsupported features for Wayland, and the recommended approach is to force the usage of X11 instead, for the time being.

(Tested and approved)