### PR TITLE
[GLFW] macOS/cocoa: do not set icon on window

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -284,8 +284,12 @@ bool SofaGLFWBaseGUI::createWindow(int width, int height, const char* title, boo
     }
     s_numberOfActiveWindows++;
 
-    setWindowIcon(glfwWindow);
-
+#ifndef __APPLE__ // Apple implies Cocoa and Cocoa does not support icon for the window
+    {
+        setWindowIcon(glfwWindow);
+    }
+#endif
+    
     if (!m_firstWindow)
         m_firstWindow = glfwWindow;
 


### PR DESCRIPTION
Remove the warning:
`[ERROR]   [SofaGLFWBaseGUI] Error: Cocoa: Regular windows do not have icons on macOS.`