### PR TITLE
Fix broken layout when imgui.ini doesn't exist

### DIFF
--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -97,6 +97,7 @@ ImGuiGUIEngine::ImGuiGUIEngine()
     , winManagerSettings(helper::system::FileSystem::append(sofaimgui::getConfigurationFolderPath(), std::string("settings.txt")))
     , winManagerViewPort(helper::system::FileSystem::append(sofaimgui::getConfigurationFolderPath(), std::string("viewport.txt")))
     , firstRunState(helper::system::FileSystem::append(sofaimgui::getConfigurationFolderPath(), std::string("firstrun.txt")))
+    , m_imguiNeedViewReset(false)
 {
 }
 
@@ -109,11 +110,15 @@ void ImGuiGUIEngine::init()
 
     ImGuiIO& io = ImGui::GetIO();
     (void)io;
-    static const std::string imguiIniFile(helper::Utils::getExecutableDirectory() + "/imgui.ini");
+    static const std::string imguiIniFile(sofaimgui::getConfigurationFolderPath() + "/imgui.ini");
+
+    m_imguiNeedViewReset = !std::filesystem::exists(imguiIniFile);
+
     io.IniFilename = imguiIniFile.c_str();
 
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
     io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
+
 
 
     ini.SetUnicode();
@@ -143,6 +148,7 @@ void ImGuiGUIEngine::init()
 
     sofa::helper::system::PluginManager::getInstance().readFromIniFile(
         sofa::gui::common::BaseGUI::getConfigDirectoryPath() + "/loadedPlugins.ini");
+
 }
 
 void ImGuiGUIEngine::initBackend(GLFWwindow* glfwWindow)
@@ -623,6 +629,12 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
         ImGui::EndMainMenuBar();
     }
 
+    if (m_imguiNeedViewReset)
+    {
+      resetView(dockspace_id, windowNameSceneGraph, windowNameLog, windowNameViewport);
+      m_imguiNeedViewReset = false;
+    }
+
     /***************************************
      * Viewport window
      **************************************/
@@ -690,12 +702,16 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 #endif // SOFAIMGUI_FORCE_OPENGL2 == 1
 
+
     // Update and Render additional Platform Windows
     if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
     {
         ImGui::UpdatePlatformWindows();
         ImGui::RenderPlatformWindowsDefault();
     }
+
+
+
 }
 
 void ImGuiGUIEngine::resetView(ImGuiID dockspace_id, const char* windowNameSceneGraph, const char *windowNameLog, const char *windowNameViewport)

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -87,6 +87,8 @@ protected:
 
     bool isViewportDisplayedForTheFirstTime{true};
     sofa::type::Vec2f lastViewPortPos;
+
+    bool m_imguiNeedViewReset;
 };
 
 } // namespace sofaimgui


### PR DESCRIPTION
The layout was completly broken if imgui.ini didn't exist, which is always the case when we first open the GUI... 

This solves the issue and put the ini file in the right directory. 