### PR TITLE
Shortcut to reload, plus cleaning

### DIFF
--- a/SofaGLFW/src/SofaGLFW/BaseGUIEngine.h
+++ b/SofaGLFW/src/SofaGLFW/BaseGUIEngine.h
@@ -41,6 +41,7 @@ public:
     virtual void afterDraw() = 0;
     virtual void terminate() = 0;
     virtual bool dispatchMouseEvents() = 0;
+    virtual void resetCounter() = 0;
 };
 
 } // namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/NullGUIEngine.cpp
+++ b/SofaGLFW/src/SofaGLFW/NullGUIEngine.cpp
@@ -61,4 +61,9 @@ bool NullGUIEngine::dispatchMouseEvents()
     return true;
 }
 
+void NullGUIEngine::resetCounter()
+{
+
+}
+
 } // namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/NullGUIEngine.h
+++ b/SofaGLFW/src/SofaGLFW/NullGUIEngine.h
@@ -41,6 +41,7 @@ public:
     void afterDraw() override {}
     void terminate() override;
     bool dispatchMouseEvents() override;
+    void resetCounter() override;
 };
 
 } // namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -319,6 +319,8 @@ void SofaGLFWWindow::mouseButtonEvent(int button, int action, int mods)
 
 bool SofaGLFWWindow::mouseEvent(GLFWwindow* window, int width, int height,int button, int action, int mods, double xpos, double ypos) const
 {
+    SOFA_UNUSED(mods);
+    
     if (!m_currentCamera)
         return true;
 

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -289,6 +289,14 @@ void ImGuiGUIEngine::loadFile(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::core::sp
 
     baseGUI->initVisual();
     
+    resetCounter();
+
+    // update camera if a sidecar file is present
+    baseGUI->restoreCamera(baseGUI->findCamera(groot));
+}
+
+void ImGuiGUIEngine::resetCounter()
+{
     // reset screenshot counter when a file is loaded
     m_screenshotCounter = 0;
 }

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -64,6 +64,9 @@ public:
     // apply global scale on the given monitor (if null, it will fetch the main monitor)
     void setScale(double globalScale, GLFWmonitor* monitor);
 
+    // reset counters
+    void resetCounter() override;
+
 protected:
     std::unique_ptr<sofa::gl::FrameBufferObject> m_fbo;
     std::pair<unsigned int, unsigned int> m_currentFBOSize;


### PR DESCRIPTION
Relates to issue #198

This allows to use the CTRL+R to reload a scene, which I was using extensively..
For a very small need, I introduced a new function `resetCounter` in BaseGUIEngine, I do not like it but it was the only way.

This PR also cleans warnings