### PR TITLE
Install dependencies libraries glfw and nfd on Windows

### DIFF
--- a/SofaGLFW/CMakeLists.txt
+++ b/SofaGLFW/CMakeLists.txt
@@ -29,6 +29,7 @@ if(NOT TARGET glfw)
     )
 
     FetchContent_GetProperties(glfw)
+    set(USE_FETCHED_GLFW ON)
     if(NOT glfw_POPULATED)
         FetchContent_Populate(glfw)
 
@@ -87,7 +88,7 @@ endif()
 
 add_definitions("-DSOFAGLFW_RESOURCES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/resources\"")
 
-if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+if(NOT USE_FETCHED_GLFW AND CMAKE_SYSTEM_NAME STREQUAL Windows)
     sofa_install_libraries(TARGETS glfw)
 endif()
 

--- a/SofaGLFW/CMakeLists.txt
+++ b/SofaGLFW/CMakeLists.txt
@@ -21,7 +21,11 @@ if( UNIX AND NOT APPLE )
 endif ()
 
 
-if(NOT TARGET glfw)
+if(TARGET glfw)
+    if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+        sofa_install_libraries(TARGETS glfw)
+    endif()
+else()
     message("glfw3 not found, fetching source code...")
     FetchContent_Declare(glfw
             GIT_REPOSITORY https://github.com/glfw/glfw
@@ -29,7 +33,6 @@ if(NOT TARGET glfw)
     )
 
     FetchContent_GetProperties(glfw)
-    set(USE_FETCHED_GLFW ON)
     if(NOT glfw_POPULATED)
         FetchContent_Populate(glfw)
 
@@ -87,10 +90,6 @@ if(SofaPython3_FOUND)
 endif()
 
 add_definitions("-DSOFAGLFW_RESOURCES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/resources\"")
-
-if(NOT USE_FETCHED_GLFW AND CMAKE_SYSTEM_NAME STREQUAL Windows)
-    sofa_install_libraries(TARGETS glfw)
-endif()
 
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}

--- a/SofaGLFW/CMakeLists.txt
+++ b/SofaGLFW/CMakeLists.txt
@@ -87,6 +87,10 @@ endif()
 
 add_definitions("-DSOFAGLFW_RESOURCES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/resources\"")
 
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+    sofa_install_libraries(TARGETS glfw)
+endif()
+
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}

--- a/SofaImGui/CMakeLists.txt
+++ b/SofaImGui/CMakeLists.txt
@@ -23,7 +23,11 @@ FetchContent_MakeAvailable(imgui)
 
 find_package(nfd CONFIG QUIET)
 
-if(NOT TARGET nfd::nfd)
+if(TARGET nfd::nfd)
+    if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+        sofa_install_libraries(TARGETS nfd::nfd)
+    endif()
+else()
     message("nativefiledialog-extended not found, fetching source code...")
     FetchContent_Declare(nfd
             GIT_REPOSITORY https://github.com/btzy/nativefiledialog-extended
@@ -159,10 +163,6 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC IMGUI_USER_CONFIG=<SofaImGui/c
 find_package(SofaPython3 QUIET)
 if(SofaPython3_FOUND)
     add_subdirectory(bindings)
-endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-    sofa_install_libraries(TARGETS nfd::nfd)
 endif()
 
 sofa_create_package_with_targets(

--- a/SofaImGui/CMakeLists.txt
+++ b/SofaImGui/CMakeLists.txt
@@ -161,6 +161,10 @@ if(SofaPython3_FOUND)
     add_subdirectory(bindings)
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+    sofa_install_libraries(TARGETS nfd::nfd)
+endif()
+
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}
     PACKAGE_VERSION ${Sofa_VERSION}


### PR DESCRIPTION
These libraries were missing from installation when building Sofa binary release package on Windows using the future Pixi pipeline.
Having a look at other plugins, this look to be the way to handle this.
Tested locally on Windows machine with the Pixi pipeline.