### PR TITLE
[GLFW] Add version requirement while find_package()-ing

### DIFF
--- a/SofaGLFW/CMakeLists.txt
+++ b/SofaGLFW/CMakeLists.txt
@@ -11,7 +11,7 @@ sofa_find_package(Sofa.GUI.Common QUIET)
 
 include(FetchContent)
 
-find_package(glfw3 CONFIG QUIET)
+find_package(glfw3 3.4 CONFIG QUIET)
 
 if( UNIX AND NOT APPLE )
     option(SOFAGLFW_USEX11 "Flag to force x11 for windows management" ON)


### PR DESCRIPTION
1) to be consistent with the fetching
2) on Ubuntu 22.04, the latest glfw package version with APT is older than 3.4. So this PR forces using the fetching mechanism to retrieve a newer version