### PR TITLE
Make the time text info more visible

### DIFF
--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -654,7 +654,7 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
             if (showFPSInMenuBar)
                 position -= ImGui::CalcTextSize("1000.0 FPS ").x;
             ImGui::SetCursorPosX(position);
-            ImGui::TextDisabled("Time: %.3f", groot->getTime());
+            ImGui::Text("Time: %.3f", groot->getTime());
             ImGui::SetCursorPosX(posX);
         }
         mainMenuBarSize = ImGui::GetWindowSize();


### PR DESCRIPTION
Depending on the theme, it may be very difficult to read the time value due to the use of `TextDisabled`