### PR TITLE
Remove printed log message when control pressed

### DIFF
--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -688,8 +688,6 @@ void SofaGLFWBaseGUI::key_callback(GLFWwindow* window, int key, int scancode, in
     {
         if (action == GLFW_PRESS)
         {
-            dmsg_info_when(key == GLFW_KEY_LEFT_CONTROL, "SofaGLFWBaseGUI") << "KeyPressEvent, CONTROL pressed";
-
             KeypressedEvent keyPressedEvent(keyName);
             rootNode->propagateEvent(core::ExecParams::defaultInstance(), &keyPressedEvent);
         }


### PR DESCRIPTION
Painful message each time control was pressed (even if it was a `dmsg()` the message was emitted anyway)