### PR TITLE
[All] Remove ON default value for projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.12)
 
 find_package(Sofa.Config REQUIRED)
 
-sofa_add_subdirectory(plugin SofaGLFW SofaGLFW ON)
-sofa_add_subdirectory(plugin SofaImGui SofaImGui ON)
+sofa_add_subdirectory(plugin SofaGLFW SofaGLFW)
+sofa_add_subdirectory(plugin SofaImGui SofaImGui)
 sofa_add_subdirectory(application exe runSofaGLFW OFF)


### PR DESCRIPTION
When adding a new plugin project into SOFA (in-tree) , there are not supposed to be ON by default.
