### PR TITLE
[ImGUI] Fix crash on exit

### DIFF
--- a/SofaGLFW/src/SofaGLFW/BaseGUIEngine.h
+++ b/SofaGLFW/src/SofaGLFW/BaseGUIEngine.h
@@ -40,6 +40,7 @@ public:
     virtual void beforeDraw(GLFWwindow* window) = 0;
     virtual void afterDraw() = 0;
     virtual void terminate() = 0;
+    virtual bool isTerminated() const = 0;
     virtual bool dispatchMouseEvents() = 0;
     virtual void resetCounter() = 0;
 };

--- a/SofaGLFW/src/SofaGLFW/NullGUIEngine.h
+++ b/SofaGLFW/src/SofaGLFW/NullGUIEngine.h
@@ -40,6 +40,7 @@ public:
     void beforeDraw(GLFWwindow* window) override;
     void afterDraw() override {}
     void terminate() override;
+    bool isTerminated() const override { return false; };
     bool dispatchMouseEvents() override;
     void resetCounter() override;
 };

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -487,7 +487,7 @@ std::size_t SofaGLFWBaseGUI::runLoop(std::size_t targetNbIterations)
             if (glfwWindow && sofaGlfwWindow)
             {
                 // while user did not request to close this window (i.e press escape), draw
-                if (!glfwWindowShouldClose(glfwWindow))
+                if (!glfwWindowShouldClose(glfwWindow) && !m_guiEngine->isTerminated())
                 {
                     makeCurrentContext(glfwWindow);
                     
@@ -520,6 +520,7 @@ std::size_t SofaGLFWBaseGUI::runLoop(std::size_t targetNbIterations)
         // the engine must be terminated before the window
         if (s_numberOfActiveWindows == closedWindows.size())
         {
+            // could be not necessary if m_guiEngine already terminated but we may need it if GLFW closed itself. (typically escape key)
             m_guiEngine->terminate();
             m_guiEngine.reset();
         }

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -820,28 +820,34 @@ void ImGuiGUIEngine::afterDraw()
 
 void ImGuiGUIEngine::terminate()
 {
-    // store window state (position and size)
-    const auto lastWindowPos = ImGui::GetMainViewport()->Pos;
-    const auto lastWindowSize = ImGui::GetMainViewport()->Size;
-    
-    // save latest window state
-    ini.SetLongValue("Window", "windowPosX", static_cast<long>(lastWindowPos.x));
-    ini.SetLongValue("Window", "windowPosY", static_cast<long>(lastWindowPos.y));
-    ini.SetLongValue("Window", "windowSizeX", static_cast<long>(lastWindowSize.x));
-    ini.SetLongValue("Window", "windowSizeY", static_cast<long>(lastWindowSize.y));
-    [[maybe_unused]] SI_Error rc = ini.SaveFile(sofaimgui::AppIniFile::getAppIniFile().c_str());
-        
-    NFD_Quit();
+    if (!this->isTerminated())
+    {
+        // store window state (position and size)
+        const auto lastWindowPos = ImGui::GetMainViewport()->Pos;
+        const auto lastWindowSize = ImGui::GetMainViewport()->Size;
+
+        // save latest window state
+        ini.SetLongValue("Window", "windowPosX", static_cast<long>(lastWindowPos.x));
+        ini.SetLongValue("Window", "windowPosY", static_cast<long>(lastWindowPos.y));
+        ini.SetLongValue("Window", "windowSizeX", static_cast<long>(lastWindowSize.x));
+        ini.SetLongValue("Window", "windowSizeY", static_cast<long>(lastWindowSize.y));
+        [[maybe_unused]] SI_Error rc = ini.SaveFile(sofaimgui::AppIniFile::getAppIniFile().c_str());
+
+        NFD_Quit();
 
 #if SOFAIMGUI_FORCE_OPENGL2 == 1
-    ImGui_ImplOpenGL2_Shutdown();
+        ImGui_ImplOpenGL2_Shutdown();
 #else
-    ImGui_ImplOpenGL3_Shutdown();
+        ImGui_ImplOpenGL3_Shutdown();
 #endif // SOFAIMGUI_FORCE_OPENGL2 == 1
 
-    ImGui_ImplGlfw_Shutdown();
-    ImPlot::DestroyContext();
-    ImGui::DestroyContext();
+        ImGui_ImplGlfw_Shutdown();
+        ImPlot::DestroyContext();
+        ImGui::DestroyContext();
+
+        m_isTerminated = true;
+
+    }
 }
 
 bool ImGuiGUIEngine::dispatchMouseEvents()

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -59,6 +59,7 @@ public:
     void beforeDraw(GLFWwindow* window) override;
     void afterDraw() override;
     void terminate() override;
+    bool isTerminated() const override { return m_isTerminated; };
     bool dispatchMouseEvents() override;
     
     // apply global scale on the given monitor (if null, it will fetch the main monitor)
@@ -95,6 +96,7 @@ protected:
     bool m_imguiNeedViewReset;
     std::string m_localeBackup;
     unsigned long m_screenshotCounter{0};
+    bool m_isTerminated{ false };
 };
 
 } // namespace sofaimgui


### PR DESCRIPTION
If exit is initiated from within imgui, a crash would appear (because the mainloop is not aware that the engine has already terminated).
This PR fixes it.

EDIT: based on 
- #232