### PR TITLE
Fix scale issue and gizmo not showing when reloading scene

### DIFF
--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -79,6 +79,7 @@
 #include <sofa/helper/io/STBImage.h>
 #include <sofa/helper/system/PluginManager.h>
 #include <sofa/version.h>
+#include <sofa/component/visual/InteractiveCamera.h>
 
 #include <clocale>
 
@@ -223,18 +224,21 @@ void ImGuiGUIEngine::loadFile(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::core::sp
     
     sofa::simulation::node::initRoot(groot.get());
 
-    auto camera = baseGUI->getCamera();
-    if (camera)
+
+    baseGUI->addCameraIfRequired();
+
+    if (baseGUI->getCamera())
     {
+
         if( groot->f_bbox.getValue().isValid())
         {
-            camera->fitBoundingBox(groot->f_bbox.getValue().minBBox(), groot->f_bbox.getValue().maxBBox());
+            baseGUI->getCamera()->fitBoundingBox(groot->f_bbox.getValue().minBBox(), groot->f_bbox.getValue().maxBBox());
         }
         else
         {
             msg_warning_when(!groot->f_bbox.getValue().isValid(), "GUI") << "Global bounding box is invalid: " << groot->f_bbox.getValue();
         }
-        baseGUI->changeCamera(camera);
+        baseGUI->changeCamera(baseGUI->getCamera());
     }
     else
     {

--- a/SofaImGui/src/SofaImGui/ObjectColor.cpp
+++ b/SofaImGui/src/SofaImGui/ObjectColor.cpp
@@ -49,7 +49,7 @@ namespace sofaimgui
             objectType=sofa::simulation::Colors::FFIELD;
         else if(object->toBaseAnimationLoop())
             objectType=sofa::simulation::Colors::SOLVER;
-        else if(object->toIntegrationScheme())
+        else if(object->toODESolver())
             objectType=sofa::simulation::Colors::SOLVER;
         else if(object->toPipeline())
             objectType=sofa::simulation::Colors::COLLISION;

--- a/SofaImGui/src/SofaImGui/ObjectColor.cpp
+++ b/SofaImGui/src/SofaImGui/ObjectColor.cpp
@@ -49,7 +49,7 @@ namespace sofaimgui
             objectType=sofa::simulation::Colors::FFIELD;
         else if(object->toBaseAnimationLoop())
             objectType=sofa::simulation::Colors::SOLVER;
-        else if(object->toODESolver())
+        else if(object->toOdeSolver())
             objectType=sofa::simulation::Colors::SOLVER;
         else if(object->toPipeline())
             objectType=sofa::simulation::Colors::COLLISION;

--- a/SofaImGui/src/SofaImGui/ObjectColor.cpp
+++ b/SofaImGui/src/SofaImGui/ObjectColor.cpp
@@ -49,7 +49,7 @@ namespace sofaimgui
             objectType=sofa::simulation::Colors::FFIELD;
         else if(object->toBaseAnimationLoop())
             objectType=sofa::simulation::Colors::SOLVER;
-        else if(object->toOdeSolver())
+        else if(object->toIntegrationScheme())
             objectType=sofa::simulation::Colors::SOLVER;
         else if(object->toPipeline())
             objectType=sofa::simulation::Colors::COLLISION;


### PR DESCRIPTION
Error was coming from the fact that when reloading, the difference was that we didn't check for a camera in the scene. Here I check and add camera when none is added to the scene.