### PR TITLE
Restore the screenshot binding

### DIFF
--- a/SofaGLFW/src/SofaGLFW/BaseGUIEngine.h
+++ b/SofaGLFW/src/SofaGLFW/BaseGUIEngine.h
@@ -52,6 +52,8 @@ public:
     virtual void loadFile(SofaGLFWBaseGUI* baseGUI, sofa::core::sptr<sofa::simulation::Node>& groot, std::string filePathName, bool reload = false)
     { SOFA_UNUSED(baseGUI); SOFA_UNUSED(groot); SOFA_UNUSED(filePathName); SOFA_UNUSED(reload); };
     virtual void contentScaleChanged(float xscale, float yscale) { SOFA_UNUSED(xscale); SOFA_UNUSED(yscale); };
+    virtual void saveScreenshot(SofaGLFWBaseGUI * baseGUI, std::string filename = std::string(""))
+    { SOFA_UNUSED(baseGUI); SOFA_UNUSED(filename); };
 };
 
 } // namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/BaseGUIEngine.h
+++ b/SofaGLFW/src/SofaGLFW/BaseGUIEngine.h
@@ -52,8 +52,8 @@ public:
     virtual void loadFile(SofaGLFWBaseGUI* baseGUI, sofa::core::sptr<sofa::simulation::Node>& groot, std::string filePathName, bool reload = false)
     { SOFA_UNUSED(baseGUI); SOFA_UNUSED(groot); SOFA_UNUSED(filePathName); SOFA_UNUSED(reload); };
     virtual void contentScaleChanged(float xscale, float yscale) { SOFA_UNUSED(xscale); SOFA_UNUSED(yscale); };
-    virtual void saveScreenshot(SofaGLFWBaseGUI * baseGUI, std::string filename = std::string(""))
-    { SOFA_UNUSED(baseGUI); SOFA_UNUSED(filename); };
+    virtual void saveNamedScreenshot(SofaGLFWBaseGUI * baseGUI, std::string filename = std::string(""), int compression_level = -1)
+    { SOFA_UNUSED(baseGUI); SOFA_UNUSED(filename); SOFA_UNUSED(compression_level); };
 };
 
 } // namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/NullGUIEngine.cpp
+++ b/SofaGLFW/src/SofaGLFW/NullGUIEngine.cpp
@@ -24,6 +24,9 @@
 #include <sofa/core/visual/VisualParams.h>
 #include <GLFW/glfw3.h>
 
+#include <sofa/helper/io/File.h>
+#include <sofa/helper/io/STBImage.h>
+
 namespace sofaglfw
 {
     
@@ -98,5 +101,26 @@ sofa::type::Vec2i NullGUIEngine::getFrameBufferPixels(std::vector<uint8_t>& pixe
     
     return {viewport[2], viewport[3]};
 }
+
+void NullGUIEngine::saveNamedScreenshot(SofaGLFWBaseGUI * baseGUI, std::string filename , int compression_level )
+{
+    sofa::helper::io::STBImage image;
+
+    GLint viewport[4];
+    glGetIntegerv(GL_VIEWPORT, viewport);
+
+    image.init(viewport[2], viewport[3], 1, 1,
+               sofa::helper::io::Image::DataType::UINT32,
+               sofa::helper::io::Image::ChannelFormat::RGBA);
+
+    glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3],
+                 GL_RGBA, GL_UNSIGNED_BYTE, image.getPixels());
+
+    if(compression_level < 0)
+        compression_level = 90;
+
+    image.save(filename, compression_level);
+
+};
 
 } // namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/NullGUIEngine.h
+++ b/SofaGLFW/src/SofaGLFW/NullGUIEngine.h
@@ -44,6 +44,8 @@ public:
     bool dispatchMouseEvents() override;
     void resetCounter() override;
     sofa::type::Vec2i getFrameBufferPixels(std::vector<uint8_t>& pixels) override;
+    virtual void saveNamedScreenshot(SofaGLFWBaseGUI * baseGUI, std::string filename = std::string(""), int compression_level = -1) override;
+
 private:
     GLFWwindow* m_window{ nullptr };
     double m_lastTime{ 0.0 };

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -84,7 +84,13 @@ public:
     void setWindowBackgroundColor(const RGBAColor& newColor, unsigned int windowID = 0);
     void setWindowBackgroundImage(const std::string& imageFileName, unsigned int windowID = 0);
     void setWindowTitle(GLFWwindow* window, const char* title);
-    
+
+    virtual void screenshot(const std::string& filename, int compression_level = 0) override
+    {
+        m_guiEngine->saveScreenshot(this, filename);
+    }
+
+
     virtual void setBackgroundColour(float r, float g, float b) override
     {
         setWindowBackgroundColor(RGBAColor{r, g, b, 1.0f}, 0);

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -85,9 +85,9 @@ public:
     void setWindowBackgroundImage(const std::string& imageFileName, unsigned int windowID = 0);
     void setWindowTitle(GLFWwindow* window, const char* title);
 
-    virtual void screenshot(const std::string& filename, int compression_level = 0) override
+    virtual void screenshot(const std::string& filename, int compression_level = -1) override
     {
-        m_guiEngine->saveScreenshot(this, filename);
+        m_guiEngine->saveNamedScreenshot(this, filename,compression_level);
     }
 
 

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.cpp
@@ -151,4 +151,10 @@ void SofaGLFWGUI::setMouseButtonConfiguration(sofa::component::setting::MouseBut
     }
 }
 
+BaseViewer* SofaGLFWGUI::getViewer()
+{
+    return &(this->m_baseGUI);
+}
+
+
 } // namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWGUI.h
@@ -53,6 +53,8 @@ public:
     void setBackgroundImage(const std::string& image) override;
     static sofa::gui::common::BaseGUI * CreateGUI(const char* name, sofa::simulation::NodeSPtr groot, const char* filename);
     void setMouseButtonConfiguration(sofa::component::setting::MouseButtonSetting *setting) override;
+
+    virtual BaseViewer* getViewer() override;
 protected:
     SofaGLFWBaseGUI m_baseGUI;
     bool m_bCreateWithFullScreen{ false };

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -313,10 +313,28 @@ void ImGuiGUIEngine::openFile(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::core::sp
     }
 }
 
-void ImGuiGUIEngine::saveScreenshot(sofaglfw::SofaGLFWBaseGUI* baseGUI, std::string filename )
+
+void ImGuiGUIEngine::saveNamedScreenshot(sofaglfw::SofaGLFWBaseGUI* baseGUI, std::string filename, int compression_level)
 {
-    nfdchar_t *outPath;
-    std::array<nfdfilteritem_t, 1> filterItem{ { {"Image", "jpg,png"} } };
+    helper::io::STBImage image;
+    image.init(m_currentFBOSize.first, m_currentFBOSize.second, 1, 1, sofa::helper::io::Image::DataType::UINT32, sofa::helper::io::Image::ChannelFormat::RGBA);
+
+    glBindTexture(GL_TEXTURE_2D, m_fbo->getColorTexture());
+
+    // Read the pixel data from the OpenGL texture
+    glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, image.getPixels());
+
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    if(compression_level < 0)
+        compression_level = 90;
+
+    image.save(filename, compression_level);
+
+}
+
+void ImGuiGUIEngine::saveScreenshot(sofaglfw::SofaGLFWBaseGUI* baseGUI)
+{
     const auto sceneFilename = baseGUI->getSceneFileName();
     std::string baseFilename{};
     if (!sceneFilename.empty())
@@ -324,26 +342,20 @@ void ImGuiGUIEngine::saveScreenshot(sofaglfw::SofaGLFWBaseGUI* baseGUI, std::str
         std::filesystem::path path(sceneFilename);
         baseFilename = path.stem().string();
     }
-    
+
     std::ostringstream oss{};
     oss << baseFilename << "_" << std::setfill('0') << std::setw(4) << m_screenshotCounter << ".png";
     m_screenshotCounter++;
 
+    nfdchar_t *outPath;
+    std::array<nfdfilteritem_t, 1> filterItem{ { {"Image", "jpg,png"} } };
+
     nfdresult_t result = NFD_SaveDialog(&outPath,
         filterItem.data(), filterItem.size(), nullptr, oss.str().c_str());
+
     if (result == NFD_OKAY)
     {
-        helper::io::STBImage image;
-        image.init(m_currentFBOSize.first, m_currentFBOSize.second, 1, 1, sofa::helper::io::Image::DataType::UINT32, sofa::helper::io::Image::ChannelFormat::RGBA);
-
-        glBindTexture(GL_TEXTURE_2D, m_fbo->getColorTexture());
-
-        // Read the pixel data from the OpenGL texture
-        glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, image.getPixels());
-
-        glBindTexture(GL_TEXTURE_2D, 0);
-
-        image.save(outPath, 90);
+        saveNamedScreenshot(baseGUI,std::string(outPath));
     }
 }
 

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -313,7 +313,7 @@ void ImGuiGUIEngine::openFile(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::core::sp
     }
 }
 
-void ImGuiGUIEngine::saveScreenshot(sofaglfw::SofaGLFWBaseGUI* baseGUI)
+void ImGuiGUIEngine::saveScreenshot(sofaglfw::SofaGLFWBaseGUI* baseGUI, std::string filename )
 {
     nfdchar_t *outPath;
     std::array<nfdfilteritem_t, 1> filterItem{ { {"Image", "jpg,png"} } };

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -75,7 +75,7 @@ public:
     void loadFile(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::core::sptr<sofa::simulation::Node>& groot, std::string filePathName, bool reload = false) override;
     
     // save screenshot
-    void saveScreenshot(sofaglfw::SofaGLFWBaseGUI* baseGUI);
+    void saveScreenshot(sofaglfw::SofaGLFWBaseGUI* baseGUI, std::string filename = std::string("")) override;
 
 protected:
     std::unique_ptr<sofa::gl::FrameBufferObject> m_fbo;

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -75,7 +75,8 @@ public:
     void loadFile(sofaglfw::SofaGLFWBaseGUI* baseGUI, sofa::core::sptr<sofa::simulation::Node>& groot, std::string filePathName, bool reload = false) override;
     
     // save screenshot
-    void saveScreenshot(sofaglfw::SofaGLFWBaseGUI* baseGUI, std::string filename = std::string("")) override;
+    void saveNamedScreenshot(sofaglfw::SofaGLFWBaseGUI* baseGUI, std::string filename = std::string(""), int compression_level = -1) override;
+    void saveScreenshot(sofaglfw::SofaGLFWBaseGUI* baseGUI);
 
 protected:
     std::unique_ptr<sofa::gl::FrameBufferObject> m_fbo;


### PR DESCRIPTION
A python3 bindeing exists to take a sceenshot 
```py
Sofa.Gui.GUIManager.SaveScreenshot("MyScreenShot.jpg")
```
But it didn't work neither with imgui nor with GLFW. This PR activates it for both. 