### PR TITLE
Fix display of SOFA version in About menu

### DIFF
--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -589,7 +589,7 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
         if (ImGui::BeginPopupModal("About SOFA", &closeButton, ImGuiWindowFlags_AlwaysAutoResize))
         {
             std::stringstream version;
-            version << SOFA_VERSION / 10000 << "." << SOFA_VERSION / 100 % 100;
+            version << SOFA_VERSION / 10000 << "." << std::setw(2) << std::setfill('0') << (SOFA_VERSION % 10000) / 100;
 
             ImGui::Text("SOFA v%s", version.str().c_str());
             ImGui::TextLinkOpenURL("Website", "https://www.sofa-framework.org/");


### PR DESCRIPTION
Before it was displaying "SOFA v26.6" now we properly have "SOFA v26.06" :heart: 