### PR TITLE
Asynchronous simulation loop

### DIFF
--- a/SofaGLFW/CMakeLists.txt
+++ b/SofaGLFW/CMakeLists.txt
@@ -49,11 +49,13 @@ set(HEADER_FILES
     ${SOFAGLFW_SOURCE_DIR}/SofaGLFWBaseGUI.h
     ${SOFAGLFW_SOURCE_DIR}/BaseGUIEngine.h
     ${SOFAGLFW_SOURCE_DIR}/NullGUIEngine.h
+    ${SOFAGLFW_SOURCE_DIR}/SimulationLoop.h
     ${SOFAGLFW_SOURCE_DIR}/SofaGLFWMouseManager.h
 )
 
 set(SOURCE_FILES
     ${SOFAGLFW_SOURCE_DIR}/initSofaGLFW.cpp
+    ${SOFAGLFW_SOURCE_DIR}/SimulationLoop.cpp
     ${SOFAGLFW_SOURCE_DIR}/SofaGLFWWindow.cpp
     ${SOFAGLFW_SOURCE_DIR}/NullGUIEngine.cpp
     ${SOFAGLFW_SOURCE_DIR}/SofaGLFWBaseGUI.cpp

--- a/SofaGLFW/CMakeLists.txt
+++ b/SofaGLFW/CMakeLists.txt
@@ -45,12 +45,14 @@ set(SOFAGLFW_SOURCE_DIR src/SofaGLFW)
 set(HEADER_FILES
     ${SOFAGLFW_SOURCE_DIR}/config.h.in
     ${SOFAGLFW_SOURCE_DIR}/init.h
+    ${SOFAGLFW_SOURCE_DIR}/CaptureSnapshotDrawTool.h
     ${SOFAGLFW_SOURCE_DIR}/SofaGLFWWindow.h
     ${SOFAGLFW_SOURCE_DIR}/SofaGLFWBaseGUI.h
     ${SOFAGLFW_SOURCE_DIR}/BaseGUIEngine.h
     ${SOFAGLFW_SOURCE_DIR}/NullGUIEngine.h
     ${SOFAGLFW_SOURCE_DIR}/SimulationLoop.h
     ${SOFAGLFW_SOURCE_DIR}/SofaGLFWMouseManager.h
+    ${SOFAGLFW_SOURCE_DIR}/SceneSnapshot.h
 )
 
 set(SOURCE_FILES
@@ -60,6 +62,8 @@ set(SOURCE_FILES
     ${SOFAGLFW_SOURCE_DIR}/NullGUIEngine.cpp
     ${SOFAGLFW_SOURCE_DIR}/SofaGLFWBaseGUI.cpp
     ${SOFAGLFW_SOURCE_DIR}/SofaGLFWMouseManager.cpp
+    ${SOFAGLFW_SOURCE_DIR}/SceneSnapshot.cpp
+    ${SOFAGLFW_SOURCE_DIR}/CaptureSnapshotDrawTool.cpp
 )
 
 if(Sofa.GUI.Common_FOUND)

--- a/SofaGLFW/CMakeLists.txt
+++ b/SofaGLFW/CMakeLists.txt
@@ -16,7 +16,7 @@ if( UNIX AND NOT APPLE )
     endif ()
 endif ()
 
-sofa_find_package(glfw3 3.4 CONFIG QUIET)
+#sofa_find_package(glfw3 3.4 CONFIG QUIET)
 
 if(TARGET glfw)
     if(CMAKE_SYSTEM_NAME STREQUAL Windows)

--- a/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.cpp
+++ b/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.cpp
@@ -5,7 +5,55 @@ namespace sofaglfw
 
 CaptureSnapshotDrawTool::CaptureSnapshotDrawTool(std::shared_ptr<SceneSnapshot>& sceneSnapshot)
     : m_sceneSnapshot(sceneSnapshot)
-{}
+{
+}
+void CaptureSnapshotDrawTool::drawPoints(const std::vector<Vec3>& points, float size,
+                                         const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawPoints(const std::vector<Vec3>& points, float size,
+                                         const std::vector<RGBAColor>& color)
+{
+}
+void CaptureSnapshotDrawTool::drawLine(const Vec3& p1, const Vec3& p2, const RGBAColor& color) {}
+void CaptureSnapshotDrawTool::drawInfiniteLine(const Vec3& point, const Vec3& direction,
+                                               const RGBAColor& color, const bool& vanishing)
+{
+}
+void CaptureSnapshotDrawTool::drawInfiniteLine(const Vec3& point, const Vec3& direction,
+                                               const float& size, const RGBAColor& color,
+                                               const bool& vanishing)
+{
+}
+void CaptureSnapshotDrawTool::drawLines(const std::vector<Vec3>& points, float size,
+                                        const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawLines(const std::vector<Vec3>& points, float size,
+                                        const std::vector<RGBAColor>& colors)
+{
+}
+void CaptureSnapshotDrawTool::drawLines(const std::vector<Vec3>& points,
+                                        const std::vector<Vec2i>& index, float size,
+                                        const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawLineStrip(const std::vector<Vec3>& points, float size,
+                                            const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawLineLoop(const std::vector<Vec3>& points, float size,
+                                           const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawDisk(float radius, double from, double to, int resolution,
+                                       const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawCircle(float radius, float lineThickness, int resolution,
+                                         const RGBAColor& color)
+{
+}
 
 void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points, const RGBAColor& color)
 {
@@ -14,5 +62,180 @@ void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points, con
         {
             drawTool->drawTriangles(pointsCopy, colorCopy);
         });
+}
+void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points, const Vec3& normal,
+                                            const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points,
+                                            const std::vector<Vec3i>& index,
+                                            const std::vector<Vec3>& normal, const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points,
+                                            const std::vector<Vec3i>& index,
+                                            const std::vector<Vec3>& normal,
+                                            const std::vector<RGBAColor>& color)
+{
+}
+void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points,
+                                            const std::vector<RGBAColor>& color)
+{
+}
+void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points,
+                                            const std::vector<Vec3>& normal,
+                                            const std::vector<RGBAColor>& color)
+{
+}
+void CaptureSnapshotDrawTool::drawTriangleStrip(const std::vector<Vec3>& points,
+                                                const std::vector<Vec3>& normal,
+                                                const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawTriangleFan(const std::vector<Vec3>& points,
+                                              const std::vector<Vec3>& normal,
+                                              const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawFrame(const Vec3& position, const Quaternion& orientation,
+                                        const Vec3f& size)
+{
+}
+void CaptureSnapshotDrawTool::drawSpheres(const std::vector<Vec3>& points,
+                                          const std::vector<float>& radius, const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawSpheres(const std::vector<Vec3>& points, float radius,
+                                          const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawFakeSpheres(const std::vector<Vec3>& points,
+                                              const std::vector<float>& radius,
+                                              const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawFakeSpheres(const std::vector<Vec3>& points, float radius,
+                                              const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawCone(const Vec3& p1, const Vec3& p2, float radius1, float radius2,
+                                       const RGBAColor& color, int subd)
+{
+}
+void CaptureSnapshotDrawTool::drawCube(const float& radius, const RGBAColor& color, const int& subd)
+{
+}
+void CaptureSnapshotDrawTool::drawCylinder(const Vec3& p1, const Vec3& p2, float radius,
+                                           const RGBAColor& color, int subd)
+{
+}
+void CaptureSnapshotDrawTool::drawCapsule(const Vec3& p1, const Vec3& p2, float radius,
+                                          const RGBAColor& color, int subd)
+{
+}
+void CaptureSnapshotDrawTool::drawArrow(const Vec3& p1, const Vec3& p2, float radius,
+                                        const RGBAColor& color, int subd)
+{
+}
+void CaptureSnapshotDrawTool::drawArrow(const Vec3& p1, const Vec3& p2, float radius,
+                                        float coneLength, const RGBAColor& color, int subd)
+{
+}
+void CaptureSnapshotDrawTool::drawArrow(const Vec3& p1, const Vec3& p2, float radius,
+                                        float coneLength, float coneRadius, const RGBAColor& color,
+                                        int subd)
+{
+}
+void CaptureSnapshotDrawTool::drawCross(const Vec3& p, float length, const RGBAColor& color) {}
+void CaptureSnapshotDrawTool::drawPlus(const float& radius, const RGBAColor& color, const int& subd)
+{
+}
+void CaptureSnapshotDrawTool::drawPoint(const Vec3& p, const RGBAColor& c) {}
+void CaptureSnapshotDrawTool::drawPoint(const Vec3& p, const Vec3& n, const RGBAColor& c) {}
+void CaptureSnapshotDrawTool::drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3,
+                                           const Vec3& normal)
+{
+}
+void CaptureSnapshotDrawTool::drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3,
+                                           const Vec3& normal, const RGBAColor& c)
+{
+}
+void CaptureSnapshotDrawTool::drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3,
+                                           const Vec3& normal, const RGBAColor& c1,
+                                           const RGBAColor& c2, const RGBAColor& c3)
+{
+}
+void CaptureSnapshotDrawTool::drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3,
+                                           const Vec3& normal1, const Vec3& normal2,
+                                           const Vec3& normal3, const RGBAColor& c1,
+                                           const RGBAColor& c2, const RGBAColor& c3)
+{
+}
+void CaptureSnapshotDrawTool::drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3,
+                                       const Vec3& p4, const Vec3& normal)
+{
+}
+void CaptureSnapshotDrawTool::drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3,
+                                       const Vec3& p4, const Vec3& normal, const RGBAColor& c)
+{
+}
+void CaptureSnapshotDrawTool::drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3,
+                                       const Vec3& p4, const Vec3& normal, const RGBAColor& c1,
+                                       const RGBAColor& c2, const RGBAColor& c3,
+                                       const RGBAColor& c4)
+{
+}
+void CaptureSnapshotDrawTool::drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3,
+                                       const Vec3& p4, const Vec3& normal1, const Vec3& normal2,
+                                       const Vec3& normal3, const Vec3& normal4,
+                                       const RGBAColor& c1, const RGBAColor& c2,
+                                       const RGBAColor& c3, const RGBAColor& c4)
+{
+}
+void CaptureSnapshotDrawTool::drawQuads(const std::vector<Vec3>& points, const RGBAColor& color) {}
+void CaptureSnapshotDrawTool::drawQuads(const std::vector<Vec3>& points,
+                                        const std::vector<RGBAColor>& colors)
+{
+}
+void CaptureSnapshotDrawTool::drawTetrahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2,
+                                              const Vec3& p3, const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawScaledTetrahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2,
+                                                    const Vec3& p3, const RGBAColor& color,
+                                                    const float scale)
+{
+}
+void CaptureSnapshotDrawTool::drawTetrahedra(const std::vector<Vec3>& points,
+                                             const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawScaledTetrahedra(const std::vector<Vec3>& points,
+                                                   const RGBAColor& color, const float scale)
+{
+}
+void CaptureSnapshotDrawTool::drawHexahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2,
+                                             const Vec3& p3, const Vec3& p4, const Vec3& p5,
+                                             const Vec3& p6, const Vec3& p7, const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawHexahedra(const std::vector<Vec3>& points, const RGBAColor& color)
+{
+}
+void CaptureSnapshotDrawTool::drawScaledHexahedra(const std::vector<Vec3>& points,
+                                                  const RGBAColor& color, const float scale)
+{
+}
+void CaptureSnapshotDrawTool::drawSphere(const Vec3& p, float radius) {}
+void CaptureSnapshotDrawTool::drawSphere(const Vec3& p, float radius, const RGBAColor& color) {}
+void CaptureSnapshotDrawTool::drawEllipsoid(const Vec3& p, const Vec3& radii) {}
+void CaptureSnapshotDrawTool::drawBoundingBox(const Vec3& min, const Vec3& max, float size) {}
+void CaptureSnapshotDrawTool::draw3DText(const Vec3& p, float scale, const RGBAColor& color,
+                                         const char* text)
+{
+}
+void CaptureSnapshotDrawTool::draw3DText_Indices(const std::vector<Vec3>& positions, float scale,
+                                                 const RGBAColor& color)
+{
 }
 }  // namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.cpp
+++ b/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.cpp
@@ -7,183 +7,374 @@ CaptureSnapshotDrawTool::CaptureSnapshotDrawTool(std::shared_ptr<SceneSnapshot>&
     : m_sceneSnapshot(sceneSnapshot)
 {
 }
+
 void CaptureSnapshotDrawTool::drawPoints(const std::vector<Vec3>& points, float size,
                                          const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, sizeCopy = size,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawPoints(pointsCopy, sizeCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawPoints(const std::vector<Vec3>& points, float size,
                                          const std::vector<RGBAColor>& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, sizeCopy = size,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawPoints(pointsCopy, sizeCopy, colorCopy); });
 }
-void CaptureSnapshotDrawTool::drawLine(const Vec3& p1, const Vec3& p2, const RGBAColor& color) {}
+void CaptureSnapshotDrawTool::drawLine(const Vec3& p1, const Vec3& p2, const RGBAColor& color)
+{
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p1Copy = p1, p2Copy = p2, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawLine(p1Copy, p2Copy, colorCopy); });
+}
 void CaptureSnapshotDrawTool::drawInfiniteLine(const Vec3& point, const Vec3& direction,
                                                const RGBAColor& color, const bool& vanishing)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointCopy = point, directionCopy = direction, colorCopy = color,
+         vanishingCopy = vanishing](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawInfiniteLine(pointCopy, directionCopy, colorCopy, vanishingCopy); });
 }
 void CaptureSnapshotDrawTool::drawInfiniteLine(const Vec3& point, const Vec3& direction,
                                                const float& size, const RGBAColor& color,
                                                const bool& vanishing)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointCopy = point, directionCopy = direction, sizeCopy = size, colorCopy = color,
+         vanishingCopy = vanishing](sofa::helper::visual::DrawTool* drawTool)
+        {
+            drawTool->drawInfiniteLine(pointCopy, directionCopy, sizeCopy, colorCopy,
+                                       vanishingCopy);
+        });
 }
 void CaptureSnapshotDrawTool::drawLines(const std::vector<Vec3>& points, float size,
                                         const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, sizeCopy = size,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawLines(pointsCopy, sizeCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawLines(const std::vector<Vec3>& points, float size,
                                         const std::vector<RGBAColor>& colors)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, sizeCopy = size,
+         colorsCopy = colors](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawLines(pointsCopy, sizeCopy, colorsCopy); });
 }
 void CaptureSnapshotDrawTool::drawLines(const std::vector<Vec3>& points,
                                         const std::vector<Vec2i>& index, float size,
                                         const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, indexCopy = index, sizeCopy = size,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawLines(pointsCopy, indexCopy, sizeCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawLineStrip(const std::vector<Vec3>& points, float size,
                                             const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, sizeCopy = size,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawLineStrip(pointsCopy, sizeCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawLineLoop(const std::vector<Vec3>& points, float size,
                                            const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, sizeCopy = size,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawLineLoop(pointsCopy, sizeCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawDisk(float radius, double from, double to, int resolution,
                                        const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [radiusCopy = radius, fromCopy = from, toCopy = to, resolutionCopy = resolution,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawDisk(radiusCopy, fromCopy, toCopy, resolutionCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawCircle(float radius, float lineThickness, int resolution,
                                          const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [radiusCopy = radius, lineThicknessCopy = lineThickness, resolutionCopy = resolution,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawCircle(radiusCopy, lineThicknessCopy, resolutionCopy, colorCopy); });
 }
 
 void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points, const RGBAColor& color)
 {
     m_sceneSnapshot->m_draws.emplace_back(
         [pointsCopy = points, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        {
-            drawTool->drawTriangles(pointsCopy, colorCopy);
-        });
+        { drawTool->drawTriangles(pointsCopy, colorCopy); });
 }
+
 void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points, const Vec3& normal,
                                             const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, normalCopy = normal,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawTriangles(pointsCopy, normalCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points,
                                             const std::vector<Vec3i>& index,
                                             const std::vector<Vec3>& normal, const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, indexCopy = index, normalCopy = normal,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawTriangles(pointsCopy, indexCopy, normalCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points,
                                             const std::vector<Vec3i>& index,
                                             const std::vector<Vec3>& normal,
                                             const std::vector<RGBAColor>& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, indexCopy = index, normalCopy = normal,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawTriangles(pointsCopy, indexCopy, normalCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points,
                                             const std::vector<RGBAColor>& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawTriangles(pointsCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points,
                                             const std::vector<Vec3>& normal,
                                             const std::vector<RGBAColor>& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, normalCopy = normal,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawTriangles(pointsCopy, normalCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawTriangleStrip(const std::vector<Vec3>& points,
                                                 const std::vector<Vec3>& normal,
                                                 const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, normalCopy = normal,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawTriangleStrip(pointsCopy, normalCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawTriangleFan(const std::vector<Vec3>& points,
                                               const std::vector<Vec3>& normal,
                                               const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, normalCopy = normal,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawTriangleFan(pointsCopy, normalCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawFrame(const Vec3& position, const Quaternion& orientation,
                                         const Vec3f& size)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [positionCopy = position, orientationCopy = orientation,
+         sizeCopy = size](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawFrame(positionCopy, orientationCopy, sizeCopy); });
+}
+void CaptureSnapshotDrawTool::drawFrame(const Vec3& position, const Quaternion& orientation,
+                                        const Vec3f& size, const RGBAColor& color)
+{
+    m_sceneSnapshot->m_draws.emplace_back(
+        [positionCopy = position, orientationCopy = orientation,
+         sizeCopy = size, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawFrame(positionCopy, orientationCopy, sizeCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawSpheres(const std::vector<Vec3>& points,
                                           const std::vector<float>& radius, const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, radiusCopy = radius,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawSpheres(pointsCopy, radiusCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawSpheres(const std::vector<Vec3>& points, float radius,
                                           const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, radiusCopy = radius,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawSpheres(pointsCopy, radiusCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawFakeSpheres(const std::vector<Vec3>& points,
                                               const std::vector<float>& radius,
                                               const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, radiusCopy = radius,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawFakeSpheres(pointsCopy, radiusCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawFakeSpheres(const std::vector<Vec3>& points, float radius,
                                               const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, radiusCopy = radius,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawFakeSpheres(pointsCopy, radiusCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawCone(const Vec3& p1, const Vec3& p2, float radius1, float radius2,
                                        const RGBAColor& color, int subd)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p1Copy = p1, p2Copy = p2, radius1Copy = radius1, radius2Copy = radius2, colorCopy = color,
+         subdCopy = subd](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawCone(p1Copy, p2Copy, radius1Copy, radius2Copy, colorCopy, subdCopy); });
 }
 void CaptureSnapshotDrawTool::drawCube(const float& radius, const RGBAColor& color, const int& subd)
 {
+    m_sceneSnapshot->m_draws.emplace_back([radiusCopy = radius, colorCopy = color, subdCopy = subd](
+                                              sofa::helper::visual::DrawTool* drawTool)
+                                          { drawTool->drawCube(radiusCopy, colorCopy, subdCopy); });
 }
 void CaptureSnapshotDrawTool::drawCylinder(const Vec3& p1, const Vec3& p2, float radius,
                                            const RGBAColor& color, int subd)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p1Copy = p1, p2Copy = p2, radiusCopy = radius, colorCopy = color,
+         subdCopy = subd](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawCylinder(p1Copy, p2Copy, radiusCopy, colorCopy, subdCopy); });
 }
 void CaptureSnapshotDrawTool::drawCapsule(const Vec3& p1, const Vec3& p2, float radius,
                                           const RGBAColor& color, int subd)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p1Copy = p1, p2Copy = p2, radiusCopy = radius, colorCopy = color,
+         subdCopy = subd](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawCapsule(p1Copy, p2Copy, radiusCopy, colorCopy, subdCopy); });
 }
 void CaptureSnapshotDrawTool::drawArrow(const Vec3& p1, const Vec3& p2, float radius,
                                         const RGBAColor& color, int subd)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p1Copy = p1, p2Copy = p2, radiusCopy = radius, colorCopy = color,
+         subdCopy = subd](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawArrow(p1Copy, p2Copy, radiusCopy, colorCopy, subdCopy); });
 }
 void CaptureSnapshotDrawTool::drawArrow(const Vec3& p1, const Vec3& p2, float radius,
                                         float coneLength, const RGBAColor& color, int subd)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p1Copy = p1, p2Copy = p2, radiusCopy = radius, coneLengthCopy = coneLength,
+         colorCopy = color, subdCopy = subd](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawArrow(p1Copy, p2Copy, radiusCopy, coneLengthCopy, colorCopy, subdCopy); });
 }
 void CaptureSnapshotDrawTool::drawArrow(const Vec3& p1, const Vec3& p2, float radius,
                                         float coneLength, float coneRadius, const RGBAColor& color,
                                         int subd)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p1Copy = p1, p2Copy = p2, radiusCopy = radius, coneLengthCopy = coneLength,
+         coneRadiusCopy = coneRadius, colorCopy = color,
+         subdCopy = subd](sofa::helper::visual::DrawTool* drawTool)
+        {
+            drawTool->drawArrow(p1Copy, p2Copy, radiusCopy, coneLengthCopy, coneRadiusCopy,
+                                colorCopy, subdCopy);
+        });
 }
-void CaptureSnapshotDrawTool::drawCross(const Vec3& p, float length, const RGBAColor& color) {}
+void CaptureSnapshotDrawTool::drawCross(const Vec3& p, float length, const RGBAColor& color)
+{
+    m_sceneSnapshot->m_draws.emplace_back([pCopy = p, lengthCopy = length, colorCopy = color](
+                                              sofa::helper::visual::DrawTool* drawTool)
+                                          { drawTool->drawCross(pCopy, lengthCopy, colorCopy); });
+}
 void CaptureSnapshotDrawTool::drawPlus(const float& radius, const RGBAColor& color, const int& subd)
 {
+    m_sceneSnapshot->m_draws.emplace_back([radiusCopy = radius, colorCopy = color, subdCopy = subd](
+                                              sofa::helper::visual::DrawTool* drawTool)
+                                          { drawTool->drawPlus(radiusCopy, colorCopy, subdCopy); });
 }
-void CaptureSnapshotDrawTool::drawPoint(const Vec3& p, const RGBAColor& c) {}
-void CaptureSnapshotDrawTool::drawPoint(const Vec3& p, const Vec3& n, const RGBAColor& c) {}
+void CaptureSnapshotDrawTool::drawPoint(const Vec3& p, const RGBAColor& c)
+{
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pCopy = p, cCopy = c](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawPoint(pCopy, cCopy); });
+}
+void CaptureSnapshotDrawTool::drawPoint(const Vec3& p, const Vec3& n, const RGBAColor& c)
+{
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pCopy = p, nCopy = n, cCopy = c](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawPoint(pCopy, nCopy, cCopy); });
+}
 void CaptureSnapshotDrawTool::drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                            const Vec3& normal)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p1Copy = p1, p2Copy = p2, p3Copy = p3,
+         normalCopy = normal](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawTriangle(p1Copy, p2Copy, p3Copy, normalCopy); });
 }
 void CaptureSnapshotDrawTool::drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                            const Vec3& normal, const RGBAColor& c)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p1Copy = p1, p2Copy = p2, p3Copy = p3, normalCopy = normal,
+         cCopy = c](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawTriangle(p1Copy, p2Copy, p3Copy, normalCopy, cCopy); });
 }
 void CaptureSnapshotDrawTool::drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                            const Vec3& normal, const RGBAColor& c1,
                                            const RGBAColor& c2, const RGBAColor& c3)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p1Copy = p1, p2Copy = p2, p3Copy = p3, normalCopy = normal, c1Copy = c1, c2Copy = c2,
+         c3Copy = c3](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawTriangle(p1Copy, p2Copy, p3Copy, normalCopy, c1Copy, c2Copy, c3Copy); });
 }
 void CaptureSnapshotDrawTool::drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                            const Vec3& normal1, const Vec3& normal2,
                                            const Vec3& normal3, const RGBAColor& c1,
                                            const RGBAColor& c2, const RGBAColor& c3)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p1Copy = p1, p2Copy = p2, p3Copy = p3, n1Copy = normal1, n2Copy = normal2,
+         n3Copy = normal3, c1Copy = c1, c2Copy = c2,
+         c3Copy = c3](sofa::helper::visual::DrawTool* drawTool)
+        {
+            drawTool->drawTriangle(p1Copy, p2Copy, p3Copy, n1Copy, n2Copy, n3Copy, c1Copy, c2Copy,
+                                   c3Copy);
+        });
 }
 void CaptureSnapshotDrawTool::drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                        const Vec3& p4, const Vec3& normal)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p1Copy = p1, p2Copy = p2, p3Copy = p3, p4Copy = p4,
+         normalCopy = normal](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawQuad(p1Copy, p2Copy, p3Copy, p4Copy, normalCopy); });
 }
 void CaptureSnapshotDrawTool::drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                        const Vec3& p4, const Vec3& normal, const RGBAColor& c)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p1Copy = p1, p2Copy = p2, p3Copy = p3, p4Copy = p4, normalCopy = normal,
+         cCopy = c](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawQuad(p1Copy, p2Copy, p3Copy, p4Copy, normalCopy, cCopy); });
 }
 void CaptureSnapshotDrawTool::drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                        const Vec3& p4, const Vec3& normal, const RGBAColor& c1,
                                        const RGBAColor& c2, const RGBAColor& c3,
                                        const RGBAColor& c4)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p1Copy = p1, p2Copy = p2, p3Copy = p3, p4Copy = p4, normalCopy = normal, c1Copy = c1,
+         c2Copy = c2, c3Copy = c3, c4Copy = c4](sofa::helper::visual::DrawTool* drawTool)
+        {
+            drawTool->drawQuad(p1Copy, p2Copy, p3Copy, p4Copy, normalCopy, c1Copy, c2Copy, c3Copy,
+                               c4Copy);
+        });
 }
 void CaptureSnapshotDrawTool::drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                        const Vec3& p4, const Vec3& normal1, const Vec3& normal2,
@@ -191,51 +382,124 @@ void CaptureSnapshotDrawTool::drawQuad(const Vec3& p1, const Vec3& p2, const Vec
                                        const RGBAColor& c1, const RGBAColor& c2,
                                        const RGBAColor& c3, const RGBAColor& c4)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p1Copy = p1, p2Copy = p2, p3Copy = p3, p4Copy = p4, n1Copy = normal1, n2Copy = normal2,
+         n3Copy = normal3, n4Copy = normal4, c1Copy = c1, c2Copy = c2, c3Copy = c3,
+         c4Copy = c4](sofa::helper::visual::DrawTool* drawTool)
+        {
+            drawTool->drawQuad(p1Copy, p2Copy, p3Copy, p4Copy, n1Copy, n2Copy, n3Copy, n4Copy,
+                               c1Copy, c2Copy, c3Copy, c4Copy);
+        });
 }
-void CaptureSnapshotDrawTool::drawQuads(const std::vector<Vec3>& points, const RGBAColor& color) {}
+void CaptureSnapshotDrawTool::drawQuads(const std::vector<Vec3>& points, const RGBAColor& color)
+{
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawQuads(pointsCopy, colorCopy); });
+}
 void CaptureSnapshotDrawTool::drawQuads(const std::vector<Vec3>& points,
                                         const std::vector<RGBAColor>& colors)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, colorsCopy = colors](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawQuads(pointsCopy, colorsCopy); });
 }
 void CaptureSnapshotDrawTool::drawTetrahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2,
                                               const Vec3& p3, const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p0Copy = p0, p1Copy = p1, p2Copy = p2, p3Copy = p3,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawTetrahedron(p0Copy, p1Copy, p2Copy, p3Copy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawScaledTetrahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2,
                                                     const Vec3& p3, const RGBAColor& color,
                                                     const float scale)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p0Copy = p0, p1Copy = p1, p2Copy = p2, p3Copy = p3, colorCopy = color,
+         scaleCopy = scale](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawScaledTetrahedron(p0Copy, p1Copy, p2Copy, p3Copy, colorCopy, scaleCopy); });
 }
 void CaptureSnapshotDrawTool::drawTetrahedra(const std::vector<Vec3>& points,
                                              const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawTetrahedra(pointsCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawScaledTetrahedra(const std::vector<Vec3>& points,
                                                    const RGBAColor& color, const float scale)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, colorCopy = color,
+         scaleCopy = scale](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawScaledTetrahedra(pointsCopy, colorCopy, scaleCopy); });
 }
 void CaptureSnapshotDrawTool::drawHexahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2,
                                              const Vec3& p3, const Vec3& p4, const Vec3& p5,
                                              const Vec3& p6, const Vec3& p7, const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [p0Copy = p0, p1Copy = p1, p2Copy = p2, p3Copy = p3, p4Copy = p4, p5Copy = p5, p6Copy = p6,
+         p7Copy = p7, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        {
+            drawTool->drawHexahedron(p0Copy, p1Copy, p2Copy, p3Copy, p4Copy, p5Copy, p6Copy, p7Copy,
+                                     colorCopy);
+        });
 }
 void CaptureSnapshotDrawTool::drawHexahedra(const std::vector<Vec3>& points, const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawHexahedra(pointsCopy, colorCopy); });
 }
 void CaptureSnapshotDrawTool::drawScaledHexahedra(const std::vector<Vec3>& points,
                                                   const RGBAColor& color, const float scale)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, colorCopy = color,
+         scaleCopy = scale](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawScaledHexahedra(pointsCopy, colorCopy, scaleCopy); });
 }
-void CaptureSnapshotDrawTool::drawSphere(const Vec3& p, float radius) {}
-void CaptureSnapshotDrawTool::drawSphere(const Vec3& p, float radius, const RGBAColor& color) {}
-void CaptureSnapshotDrawTool::drawEllipsoid(const Vec3& p, const Vec3& radii) {}
-void CaptureSnapshotDrawTool::drawBoundingBox(const Vec3& min, const Vec3& max, float size) {}
+void CaptureSnapshotDrawTool::drawSphere(const Vec3& p, float radius)
+{
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pCopy = p, radiusCopy = radius](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawSphere(pCopy, radiusCopy); });
+}
+void CaptureSnapshotDrawTool::drawSphere(const Vec3& p, float radius, const RGBAColor& color)
+{
+    m_sceneSnapshot->m_draws.emplace_back([pCopy = p, radiusCopy = radius, colorCopy = color](
+                                              sofa::helper::visual::DrawTool* drawTool)
+                                          { drawTool->drawSphere(pCopy, radiusCopy, colorCopy); });
+}
+void CaptureSnapshotDrawTool::drawEllipsoid(const Vec3& p, const Vec3& radii)
+{
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pCopy = p, radiiCopy = radii](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawEllipsoid(pCopy, radiiCopy); });
+}
+void CaptureSnapshotDrawTool::drawBoundingBox(const Vec3& min, const Vec3& max, float size)
+{
+    m_sceneSnapshot->m_draws.emplace_back(
+        [minCopy = min, maxCopy = max, sizeCopy = size](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->drawBoundingBox(minCopy, maxCopy, sizeCopy); });
+}
 void CaptureSnapshotDrawTool::draw3DText(const Vec3& p, float scale, const RGBAColor& color,
                                          const char* text)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pCopy = p, scaleCopy = scale, colorCopy = color,
+         textCopy = std::string(text)](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->draw3DText(pCopy, scaleCopy, colorCopy, textCopy.c_str()); });
 }
 void CaptureSnapshotDrawTool::draw3DText_Indices(const std::vector<Vec3>& positions, float scale,
                                                  const RGBAColor& color)
 {
+    m_sceneSnapshot->m_draws.emplace_back(
+        [positionsCopy = positions, scaleCopy = scale,
+         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        { drawTool->draw3DText_Indices(positionsCopy, scaleCopy, colorCopy); });
 }
 }  // namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.cpp
+++ b/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.cpp
@@ -1,0 +1,18 @@
+#include <SofaGLFW/CaptureSnapshotDrawTool.h>
+
+namespace sofaglfw
+{
+
+CaptureSnapshotDrawTool::CaptureSnapshotDrawTool(std::shared_ptr<SceneSnapshot>& sceneSnapshot)
+    : m_sceneSnapshot(sceneSnapshot)
+{}
+
+void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points, const RGBAColor& color)
+{
+    m_sceneSnapshot->m_draws.emplace_back(
+        [pointsCopy = points, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+        {
+            drawTool->drawTriangles(pointsCopy, colorCopy);
+        });
+}
+}  // namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.cpp
+++ b/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.cpp
@@ -11,495 +11,1269 @@ CaptureSnapshotDrawTool::CaptureSnapshotDrawTool(std::shared_ptr<SceneSnapshot>&
 void CaptureSnapshotDrawTool::drawPoints(const std::vector<Vec3>& points, float size,
                                          const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, sizeCopy = size,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawPoints(pointsCopy, sizeCopy, colorCopy); });
+    struct DrawPoints : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        float m_size;
+        RGBAColor m_color;
+
+        DrawPoints(const std::vector<Vec3>& points, float size, const RGBAColor& color)
+            : m_points(points), m_size(size), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawPoints(m_points, m_size, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawPoints(points, size, color));
 }
+
+
 void CaptureSnapshotDrawTool::drawPoints(const std::vector<Vec3>& points, float size,
                                          const std::vector<RGBAColor>& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, sizeCopy = size,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawPoints(pointsCopy, sizeCopy, colorCopy); });
+    struct DrawPoints : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        float m_size;
+        std::vector<RGBAColor> m_color;
+
+        DrawPoints(const std::vector<Vec3>& points, float size, const std::vector<RGBAColor>& color)
+            : m_points(points), m_size(size), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawPoints(m_points, m_size, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawPoints(points, size, color));
 }
+
 void CaptureSnapshotDrawTool::drawLine(const Vec3& p1, const Vec3& p2, const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p1Copy = p1, p2Copy = p2, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawLine(p1Copy, p2Copy, colorCopy); });
+    struct DrawLine : public DrawToolSnapshot
+    {
+        Vec3 m_p1, m_p2;
+        RGBAColor m_color;
+
+        DrawLine(const Vec3& p1, const Vec3& p2, const RGBAColor& color)
+            : m_p1(p1), m_p2(p2), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawLine(m_p1, m_p2, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawLine(p1, p2, color));
 }
+
 void CaptureSnapshotDrawTool::drawInfiniteLine(const Vec3& point, const Vec3& direction,
                                                const RGBAColor& color, const bool& vanishing)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointCopy = point, directionCopy = direction, colorCopy = color,
-         vanishingCopy = vanishing](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawInfiniteLine(pointCopy, directionCopy, colorCopy, vanishingCopy); });
+    struct DrawInfiniteLine : public DrawToolSnapshot
+    {
+        Vec3 m_point, m_direction;
+        RGBAColor m_color;
+        bool m_vanishing;
+
+        DrawInfiniteLine(const Vec3& point, const Vec3& direction, const RGBAColor& color, bool vanishing)
+            : m_point(point), m_direction(direction), m_color(color), m_vanishing(vanishing) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawInfiniteLine(m_point, m_direction, m_color, m_vanishing);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawInfiniteLine(point, direction, color, vanishing));
 }
+
 void CaptureSnapshotDrawTool::drawInfiniteLine(const Vec3& point, const Vec3& direction,
                                                const float& size, const RGBAColor& color,
                                                const bool& vanishing)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointCopy = point, directionCopy = direction, sizeCopy = size, colorCopy = color,
-         vanishingCopy = vanishing](sofa::helper::visual::DrawTool* drawTool)
+    struct DrawInfiniteLineSized : public DrawToolSnapshot
+    {
+        Vec3 m_point, m_direction;
+        float m_size;
+        RGBAColor m_color;
+        bool m_vanishing;
+
+        DrawInfiniteLineSized(const Vec3& point, const Vec3& direction, float size, const RGBAColor& color, bool vanishing)
+            : m_point(point), m_direction(direction), m_size(size), m_color(color), m_vanishing(vanishing) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
         {
-            drawTool->drawInfiniteLine(pointCopy, directionCopy, sizeCopy, colorCopy,
-                                       vanishingCopy);
-        });
+            drawTool->drawInfiniteLine(m_point, m_direction, m_size, m_color, m_vanishing);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawInfiniteLineSized(point, direction, size, color, vanishing));
 }
+
 void CaptureSnapshotDrawTool::drawLines(const std::vector<Vec3>& points, float size,
                                         const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, sizeCopy = size,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawLines(pointsCopy, sizeCopy, colorCopy); });
+    struct DrawLines : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        float m_size;
+        RGBAColor m_color;
+
+        DrawLines(const std::vector<Vec3>& points, float size, const RGBAColor& color)
+            : m_points(points), m_size(size), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawLines(m_points, m_size, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawLines(points, size, color));
 }
+
 void CaptureSnapshotDrawTool::drawLines(const std::vector<Vec3>& points, float size,
                                         const std::vector<RGBAColor>& colors)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, sizeCopy = size,
-         colorsCopy = colors](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawLines(pointsCopy, sizeCopy, colorsCopy); });
+    struct DrawLinesCol : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        float m_size;
+        std::vector<RGBAColor> m_colors;
+
+        DrawLinesCol(const std::vector<Vec3>& points, float size, const std::vector<RGBAColor>& colors)
+            : m_points(points), m_size(size), m_colors(colors) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawLines(m_points, m_size, m_colors);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawLinesCol(points, size, colors));
 }
+
 void CaptureSnapshotDrawTool::drawLines(const std::vector<Vec3>& points,
                                         const std::vector<Vec2i>& index, float size,
                                         const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, indexCopy = index, sizeCopy = size,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawLines(pointsCopy, indexCopy, sizeCopy, colorCopy); });
+    struct DrawLinesIndexed : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        std::vector<Vec2i> m_index;
+        float m_size;
+        RGBAColor m_color;
+
+        DrawLinesIndexed(const std::vector<Vec3>& points, const std::vector<Vec2i>& index, float size, const RGBAColor& color)
+            : m_points(points), m_index(index), m_size(size), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawLines(m_points, m_index, m_size, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawLinesIndexed(points, index, size, color));
 }
+
 void CaptureSnapshotDrawTool::drawLineStrip(const std::vector<Vec3>& points, float size,
                                             const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, sizeCopy = size,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawLineStrip(pointsCopy, sizeCopy, colorCopy); });
+    struct DrawLineStrip : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        float m_size;
+        RGBAColor m_color;
+
+        DrawLineStrip(const std::vector<Vec3>& points, float size, const RGBAColor& color)
+            : m_points(points), m_size(size), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawLineStrip(m_points, m_size, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawLineStrip(points, size, color));
 }
+
 void CaptureSnapshotDrawTool::drawLineLoop(const std::vector<Vec3>& points, float size,
                                            const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, sizeCopy = size,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawLineLoop(pointsCopy, sizeCopy, colorCopy); });
+    struct DrawLineLoop : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        float m_size;
+        RGBAColor m_color;
+
+        DrawLineLoop(const std::vector<Vec3>& points, float size, const RGBAColor& color)
+            : m_points(points), m_size(size), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawLineLoop(m_points, m_size, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawLineLoop(points, size, color));
 }
+
 void CaptureSnapshotDrawTool::drawDisk(float radius, double from, double to, int resolution,
                                        const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [radiusCopy = radius, fromCopy = from, toCopy = to, resolutionCopy = resolution,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawDisk(radiusCopy, fromCopy, toCopy, resolutionCopy, colorCopy); });
+    struct DrawDisk : public DrawToolSnapshot
+    {
+        float m_radius;
+        double m_from, m_to;
+        int m_resolution;
+        RGBAColor m_color;
+
+        DrawDisk(float radius, double from, double to, int resolution, const RGBAColor& color)
+            : m_radius(radius), m_from(from), m_to(to), m_resolution(resolution), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawDisk(m_radius, m_from, m_to, m_resolution, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawDisk(radius, from, to, resolution, color));
 }
+
 void CaptureSnapshotDrawTool::drawCircle(float radius, float lineThickness, int resolution,
                                          const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [radiusCopy = radius, lineThicknessCopy = lineThickness, resolutionCopy = resolution,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawCircle(radiusCopy, lineThicknessCopy, resolutionCopy, colorCopy); });
+    struct DrawCircle : public DrawToolSnapshot
+    {
+        float m_radius, m_lineThickness;
+        int m_resolution;
+        RGBAColor m_color;
+
+        DrawCircle(float radius, float lineThickness, int resolution, const RGBAColor& color)
+            : m_radius(radius), m_lineThickness(lineThickness), m_resolution(resolution), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawCircle(m_radius, m_lineThickness, m_resolution, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawCircle(radius, lineThickness, resolution, color));
 }
 
 void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points, const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawTriangles(pointsCopy, colorCopy); });
+    struct DrawTriangles : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        RGBAColor m_color;
+
+        DrawTriangles(const std::vector<Vec3>& points, const RGBAColor& color)
+            : m_points(points), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawTriangles(m_points, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawTriangles(points, color));
 }
 
 void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points, const Vec3& normal,
                                             const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, normalCopy = normal,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawTriangles(pointsCopy, normalCopy, colorCopy); });
+    struct DrawTrianglesNorm : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        Vec3 m_normal;
+        RGBAColor m_color;
+
+        DrawTrianglesNorm(const std::vector<Vec3>& points, const Vec3& normal, const RGBAColor& color)
+            : m_points(points), m_normal(normal), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawTriangles(m_points, m_normal, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawTrianglesNorm(points, normal, color));
 }
+
 void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points,
                                             const std::vector<Vec3i>& index,
                                             const std::vector<Vec3>& normal, const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, indexCopy = index, normalCopy = normal,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawTriangles(pointsCopy, indexCopy, normalCopy, colorCopy); });
+    struct DrawTrianglesIndexed : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        std::vector<Vec3i> m_index;
+        std::vector<Vec3> m_normal;
+        RGBAColor m_color;
+
+        DrawTrianglesIndexed(const std::vector<Vec3>& points, const std::vector<Vec3i>& index,
+                             const std::vector<Vec3>& normal, const RGBAColor& color)
+            : m_points(points), m_index(index), m_normal(normal), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawTriangles(m_points, m_index, m_normal, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawTrianglesIndexed(points, index, normal, color));
 }
+
 void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points,
                                             const std::vector<Vec3i>& index,
                                             const std::vector<Vec3>& normal,
                                             const std::vector<RGBAColor>& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, indexCopy = index, normalCopy = normal,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawTriangles(pointsCopy, indexCopy, normalCopy, colorCopy); });
+    struct DrawTrianglesIndexedCol : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        std::vector<Vec3i> m_index;
+        std::vector<Vec3> m_normal;
+        std::vector<RGBAColor> m_color;
+
+        DrawTrianglesIndexedCol(const std::vector<Vec3>& points, const std::vector<Vec3i>& index,
+                                const std::vector<Vec3>& normal, const std::vector<RGBAColor>& color)
+            : m_points(points), m_index(index), m_normal(normal), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawTriangles(m_points, m_index, m_normal, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawTrianglesIndexedCol(points, index, normal, color));
 }
+
 void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points,
                                             const std::vector<RGBAColor>& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawTriangles(pointsCopy, colorCopy); });
+    struct DrawTrianglesCol : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        std::vector<RGBAColor> m_color;
+
+        DrawTrianglesCol(const std::vector<Vec3>& points, const std::vector<RGBAColor>& color)
+            : m_points(points), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawTriangles(m_points, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawTrianglesCol(points, color));
 }
+
 void CaptureSnapshotDrawTool::drawTriangles(const std::vector<Vec3>& points,
                                             const std::vector<Vec3>& normal,
                                             const std::vector<RGBAColor>& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, normalCopy = normal,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawTriangles(pointsCopy, normalCopy, colorCopy); });
+    struct DrawTrianglesNormCol : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        std::vector<Vec3> m_normal;
+        std::vector<RGBAColor> m_color;
+
+        DrawTrianglesNormCol(const std::vector<Vec3>& points, const std::vector<Vec3>& normal,
+                             const std::vector<RGBAColor>& color)
+            : m_points(points), m_normal(normal), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawTriangles(m_points, m_normal, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawTrianglesNormCol(points, normal, color));
 }
+
 void CaptureSnapshotDrawTool::drawTriangleStrip(const std::vector<Vec3>& points,
                                                 const std::vector<Vec3>& normal,
                                                 const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, normalCopy = normal,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawTriangleStrip(pointsCopy, normalCopy, colorCopy); });
+    struct DrawTriangleStrip : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        std::vector<Vec3> m_normal;
+        RGBAColor m_color;
+
+        DrawTriangleStrip(const std::vector<Vec3>& points, const std::vector<Vec3>& normal, const RGBAColor& color)
+            : m_points(points), m_normal(normal), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawTriangleStrip(m_points, m_normal, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawTriangleStrip(points, normal, color));
 }
+
 void CaptureSnapshotDrawTool::drawTriangleFan(const std::vector<Vec3>& points,
                                               const std::vector<Vec3>& normal,
                                               const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, normalCopy = normal,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawTriangleFan(pointsCopy, normalCopy, colorCopy); });
+    struct DrawTriangleFan : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        std::vector<Vec3> m_normal;
+        RGBAColor m_color;
+
+        DrawTriangleFan(const std::vector<Vec3>& points, const std::vector<Vec3>& normal, const RGBAColor& color)
+            : m_points(points), m_normal(normal), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawTriangleFan(m_points, m_normal, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawTriangleFan(points, normal, color));
 }
+
 void CaptureSnapshotDrawTool::drawFrame(const Vec3& position, const Quaternion& orientation,
                                         const Vec3f& size)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [positionCopy = position, orientationCopy = orientation,
-         sizeCopy = size](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawFrame(positionCopy, orientationCopy, sizeCopy); });
+    struct DrawFrame : public DrawToolSnapshot
+    {
+        Vec3 m_position;
+        Quaternion m_orientation;
+        Vec3f m_size;
+
+        DrawFrame(const Vec3& position, const Quaternion& orientation, const Vec3f& size)
+            : m_position(position), m_orientation(orientation), m_size(size) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawFrame(m_position, m_orientation, m_size);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawFrame(position, orientation, size));
 }
+
 void CaptureSnapshotDrawTool::drawFrame(const Vec3& position, const Quaternion& orientation,
                                         const Vec3f& size, const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [positionCopy = position, orientationCopy = orientation,
-         sizeCopy = size, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawFrame(positionCopy, orientationCopy, sizeCopy, colorCopy); });
+    struct DrawFrameCol : public DrawToolSnapshot
+    {
+        Vec3 m_position;
+        Quaternion m_orientation;
+        Vec3f m_size;
+        RGBAColor m_color;
+
+        DrawFrameCol(const Vec3& position, const Quaternion& orientation, const Vec3f& size, const RGBAColor& color)
+            : m_position(position), m_orientation(orientation), m_size(size), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawFrame(m_position, m_orientation, m_size, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawFrameCol(position, orientation, size, color));
 }
+
 void CaptureSnapshotDrawTool::drawSpheres(const std::vector<Vec3>& points,
                                           const std::vector<float>& radius, const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, radiusCopy = radius,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawSpheres(pointsCopy, radiusCopy, colorCopy); });
+    struct DrawSpheres : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        std::vector<float> m_radius;
+        RGBAColor m_color;
+
+        DrawSpheres(const std::vector<Vec3>& points, const std::vector<float>& radius, const RGBAColor& color)
+            : m_points(points), m_radius(radius), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawSpheres(m_points, m_radius, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawSpheres(points, radius, color));
 }
+
 void CaptureSnapshotDrawTool::drawSpheres(const std::vector<Vec3>& points, float radius,
                                           const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, radiusCopy = radius,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawSpheres(pointsCopy, radiusCopy, colorCopy); });
+    struct DrawSpheresUniform : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        float m_radius;
+        RGBAColor m_color;
+
+        DrawSpheresUniform(const std::vector<Vec3>& points, float radius, const RGBAColor& color)
+            : m_points(points), m_radius(radius), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawSpheres(m_points, m_radius, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawSpheresUniform(points, radius, color));
 }
+
 void CaptureSnapshotDrawTool::drawFakeSpheres(const std::vector<Vec3>& points,
                                               const std::vector<float>& radius,
                                               const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, radiusCopy = radius,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawFakeSpheres(pointsCopy, radiusCopy, colorCopy); });
+    struct DrawFakeSpheres : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        std::vector<float> m_radius;
+        RGBAColor m_color;
+
+        DrawFakeSpheres(const std::vector<Vec3>& points, const std::vector<float>& radius, const RGBAColor& color)
+            : m_points(points), m_radius(radius), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawFakeSpheres(m_points, m_radius, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawFakeSpheres(points, radius, color));
 }
+
 void CaptureSnapshotDrawTool::drawFakeSpheres(const std::vector<Vec3>& points, float radius,
                                               const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, radiusCopy = radius,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawFakeSpheres(pointsCopy, radiusCopy, colorCopy); });
+    struct DrawFakeSpheresUniform : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        float m_radius;
+        RGBAColor m_color;
+
+        DrawFakeSpheresUniform(const std::vector<Vec3>& points, float radius, const RGBAColor& color)
+            : m_points(points), m_radius(radius), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawFakeSpheres(m_points, m_radius, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawFakeSpheresUniform(points, radius, color));
 }
+
 void CaptureSnapshotDrawTool::drawCone(const Vec3& p1, const Vec3& p2, float radius1, float radius2,
                                        const RGBAColor& color, int subd)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p1Copy = p1, p2Copy = p2, radius1Copy = radius1, radius2Copy = radius2, colorCopy = color,
-         subdCopy = subd](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawCone(p1Copy, p2Copy, radius1Copy, radius2Copy, colorCopy, subdCopy); });
+    struct DrawCone : public DrawToolSnapshot
+    {
+        Vec3 m_p1, m_p2;
+        float m_radius1, m_radius2;
+        RGBAColor m_color;
+        int m_subd;
+
+        DrawCone(const Vec3& p1, const Vec3& p2, float radius1, float radius2, const RGBAColor& color, int subd)
+            : m_p1(p1), m_p2(p2), m_radius1(radius1), m_radius2(radius2), m_color(color), m_subd(subd) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawCone(m_p1, m_p2, m_radius1, m_radius2, m_color, m_subd);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawCone(p1, p2, radius1, radius2, color, subd));
 }
+
 void CaptureSnapshotDrawTool::drawCube(const float& radius, const RGBAColor& color, const int& subd)
 {
-    m_sceneSnapshot->m_draws.emplace_back([radiusCopy = radius, colorCopy = color, subdCopy = subd](
-                                              sofa::helper::visual::DrawTool* drawTool)
-                                          { drawTool->drawCube(radiusCopy, colorCopy, subdCopy); });
+    struct DrawCube : public DrawToolSnapshot
+    {
+        float m_radius;
+        RGBAColor m_color;
+        int m_subd;
+
+        DrawCube(float radius, const RGBAColor& color, int subd)
+            : m_radius(radius), m_color(color), m_subd(subd) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawCube(m_radius, m_color, m_subd);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawCube(radius, color, subd));
 }
+
 void CaptureSnapshotDrawTool::drawCylinder(const Vec3& p1, const Vec3& p2, float radius,
                                            const RGBAColor& color, int subd)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p1Copy = p1, p2Copy = p2, radiusCopy = radius, colorCopy = color,
-         subdCopy = subd](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawCylinder(p1Copy, p2Copy, radiusCopy, colorCopy, subdCopy); });
+    struct DrawCylinder : public DrawToolSnapshot
+    {
+        Vec3 m_p1, m_p2;
+        float m_radius;
+        RGBAColor m_color;
+        int m_subd;
+
+        DrawCylinder(const Vec3& p1, const Vec3& p2, float radius, const RGBAColor& color, int subd)
+            : m_p1(p1), m_p2(p2), m_radius(radius), m_color(color), m_subd(subd) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawCylinder(m_p1, m_p2, m_radius, m_color, m_subd);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawCylinder(p1, p2, radius, color, subd));
 }
+
 void CaptureSnapshotDrawTool::drawCapsule(const Vec3& p1, const Vec3& p2, float radius,
                                           const RGBAColor& color, int subd)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p1Copy = p1, p2Copy = p2, radiusCopy = radius, colorCopy = color,
-         subdCopy = subd](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawCapsule(p1Copy, p2Copy, radiusCopy, colorCopy, subdCopy); });
+    struct DrawCapsule : public DrawToolSnapshot
+    {
+        Vec3 m_p1, m_p2;
+        float m_radius;
+        RGBAColor m_color;
+        int m_subd;
+
+        DrawCapsule(const Vec3& p1, const Vec3& p2, float radius, const RGBAColor& color, int subd)
+            : m_p1(p1), m_p2(p2), m_radius(radius), m_color(color), m_subd(subd) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawCapsule(m_p1, m_p2, m_radius, m_color, m_subd);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawCapsule(p1, p2, radius, color, subd));
 }
+
 void CaptureSnapshotDrawTool::drawArrow(const Vec3& p1, const Vec3& p2, float radius,
                                         const RGBAColor& color, int subd)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p1Copy = p1, p2Copy = p2, radiusCopy = radius, colorCopy = color,
-         subdCopy = subd](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawArrow(p1Copy, p2Copy, radiusCopy, colorCopy, subdCopy); });
+    struct DrawArrow : public DrawToolSnapshot
+    {
+        Vec3 m_p1, m_p2;
+        float m_radius;
+        RGBAColor m_color;
+        int m_subd;
+
+        DrawArrow(const Vec3& p1, const Vec3& p2, float radius, const RGBAColor& color, int subd)
+            : m_p1(p1), m_p2(p2), m_radius(radius), m_color(color), m_subd(subd) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawArrow(m_p1, m_p2, m_radius, m_color, m_subd);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawArrow(p1, p2, radius, color, subd));
 }
+
 void CaptureSnapshotDrawTool::drawArrow(const Vec3& p1, const Vec3& p2, float radius,
                                         float coneLength, const RGBAColor& color, int subd)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p1Copy = p1, p2Copy = p2, radiusCopy = radius, coneLengthCopy = coneLength,
-         colorCopy = color, subdCopy = subd](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawArrow(p1Copy, p2Copy, radiusCopy, coneLengthCopy, colorCopy, subdCopy); });
+    struct DrawArrowCL : public DrawToolSnapshot
+    {
+        Vec3 m_p1, m_p2;
+        float m_radius, m_coneLength;
+        RGBAColor m_color;
+        int m_subd;
+
+        DrawArrowCL(const Vec3& p1, const Vec3& p2, float radius, float coneLength, const RGBAColor& color, int subd)
+            : m_p1(p1), m_p2(p2), m_radius(radius), m_coneLength(coneLength), m_color(color), m_subd(subd) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawArrow(m_p1, m_p2, m_radius, m_coneLength, m_color, m_subd);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawArrowCL(p1, p2, radius, coneLength, color, subd));
 }
+
 void CaptureSnapshotDrawTool::drawArrow(const Vec3& p1, const Vec3& p2, float radius,
                                         float coneLength, float coneRadius, const RGBAColor& color,
                                         int subd)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p1Copy = p1, p2Copy = p2, radiusCopy = radius, coneLengthCopy = coneLength,
-         coneRadiusCopy = coneRadius, colorCopy = color,
-         subdCopy = subd](sofa::helper::visual::DrawTool* drawTool)
+    struct DrawArrowCLR : public DrawToolSnapshot
+    {
+        Vec3 m_p1, m_p2;
+        float m_radius, m_coneLength, m_coneRadius;
+        RGBAColor m_color;
+        int m_subd;
+
+        DrawArrowCLR(const Vec3& p1, const Vec3& p2, float radius, float coneLength, float coneRadius, const RGBAColor& color, int subd)
+            : m_p1(p1), m_p2(p2), m_radius(radius), m_coneLength(coneLength), m_coneRadius(coneRadius), m_color(color), m_subd(subd) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
         {
-            drawTool->drawArrow(p1Copy, p2Copy, radiusCopy, coneLengthCopy, coneRadiusCopy,
-                                colorCopy, subdCopy);
-        });
+            drawTool->drawArrow(m_p1, m_p2, m_radius, m_coneLength, m_coneRadius, m_color, m_subd);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawArrowCLR(p1, p2, radius, coneLength, coneRadius, color, subd));
 }
+
 void CaptureSnapshotDrawTool::drawCross(const Vec3& p, float length, const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back([pCopy = p, lengthCopy = length, colorCopy = color](
-                                              sofa::helper::visual::DrawTool* drawTool)
-                                          { drawTool->drawCross(pCopy, lengthCopy, colorCopy); });
+    struct DrawCross : public DrawToolSnapshot
+    {
+        Vec3 m_p;
+        float m_length;
+        RGBAColor m_color;
+
+        DrawCross(const Vec3& p, float length, const RGBAColor& color)
+            : m_p(p), m_length(length), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawCross(m_p, m_length, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawCross(p, length, color));
 }
+
 void CaptureSnapshotDrawTool::drawPlus(const float& radius, const RGBAColor& color, const int& subd)
 {
-    m_sceneSnapshot->m_draws.emplace_back([radiusCopy = radius, colorCopy = color, subdCopy = subd](
-                                              sofa::helper::visual::DrawTool* drawTool)
-                                          { drawTool->drawPlus(radiusCopy, colorCopy, subdCopy); });
+    struct DrawPlus : public DrawToolSnapshot
+    {
+        float m_radius;
+        RGBAColor m_color;
+        int m_subd;
+
+        DrawPlus(float radius, const RGBAColor& color, int subd)
+            : m_radius(radius), m_color(color), m_subd(subd) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawPlus(m_radius, m_color, m_subd);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawPlus(radius, color, subd));
 }
+
 void CaptureSnapshotDrawTool::drawPoint(const Vec3& p, const RGBAColor& c)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pCopy = p, cCopy = c](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawPoint(pCopy, cCopy); });
+    struct DrawPoint : public DrawToolSnapshot
+    {
+        Vec3 m_p;
+        RGBAColor m_c;
+
+        DrawPoint(const Vec3& p, const RGBAColor& c)
+            : m_p(p), m_c(c) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawPoint(m_p, m_c);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawPoint(p, c));
 }
+
 void CaptureSnapshotDrawTool::drawPoint(const Vec3& p, const Vec3& n, const RGBAColor& c)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pCopy = p, nCopy = n, cCopy = c](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawPoint(pCopy, nCopy, cCopy); });
+    struct DrawPointNorm : public DrawToolSnapshot
+    {
+        Vec3 m_p, m_n;
+        RGBAColor m_c;
+
+        DrawPointNorm(const Vec3& p, const Vec3& n, const RGBAColor& c)
+            : m_p(p), m_n(n), m_c(c) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawPoint(m_p, m_n, m_c);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawPointNorm(p, n, c));
 }
+
 void CaptureSnapshotDrawTool::drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                            const Vec3& normal)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p1Copy = p1, p2Copy = p2, p3Copy = p3,
-         normalCopy = normal](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawTriangle(p1Copy, p2Copy, p3Copy, normalCopy); });
+    struct DrawTriangle : public DrawToolSnapshot
+    {
+        Vec3 m_p1, m_p2, m_p3, m_normal;
+
+        DrawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& normal)
+            : m_p1(p1), m_p2(p2), m_p3(p3), m_normal(normal) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawTriangle(m_p1, m_p2, m_p3, m_normal);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawTriangle(p1, p2, p3, normal));
 }
+
 void CaptureSnapshotDrawTool::drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                            const Vec3& normal, const RGBAColor& c)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p1Copy = p1, p2Copy = p2, p3Copy = p3, normalCopy = normal,
-         cCopy = c](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawTriangle(p1Copy, p2Copy, p3Copy, normalCopy, cCopy); });
+    struct DrawTriangleCol : public DrawToolSnapshot
+    {
+        Vec3 m_p1, m_p2, m_p3, m_normal;
+        RGBAColor m_c;
+
+        DrawTriangleCol(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& normal, const RGBAColor& c)
+            : m_p1(p1), m_p2(p2), m_p3(p3), m_normal(normal), m_c(c) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawTriangle(m_p1, m_p2, m_p3, m_normal, m_c);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawTriangleCol(p1, p2, p3, normal, c));
 }
+
 void CaptureSnapshotDrawTool::drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                            const Vec3& normal, const RGBAColor& c1,
                                            const RGBAColor& c2, const RGBAColor& c3)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p1Copy = p1, p2Copy = p2, p3Copy = p3, normalCopy = normal, c1Copy = c1, c2Copy = c2,
-         c3Copy = c3](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawTriangle(p1Copy, p2Copy, p3Copy, normalCopy, c1Copy, c2Copy, c3Copy); });
+    struct DrawTriangleVCol : public DrawToolSnapshot
+    {
+        Vec3 m_p1, m_p2, m_p3, m_normal;
+        RGBAColor m_c1, m_c2, m_c3;
+
+        DrawTriangleVCol(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& normal,
+                         const RGBAColor& c1, const RGBAColor& c2, const RGBAColor& c3)
+            : m_p1(p1), m_p2(p2), m_p3(p3), m_normal(normal), m_c1(c1), m_c2(c2), m_c3(c3) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawTriangle(m_p1, m_p2, m_p3, m_normal, m_c1, m_c2, m_c3);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawTriangleVCol(p1, p2, p3, normal, c1, c2, c3));
 }
+
 void CaptureSnapshotDrawTool::drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                            const Vec3& normal1, const Vec3& normal2,
                                            const Vec3& normal3, const RGBAColor& c1,
                                            const RGBAColor& c2, const RGBAColor& c3)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p1Copy = p1, p2Copy = p2, p3Copy = p3, n1Copy = normal1, n2Copy = normal2,
-         n3Copy = normal3, c1Copy = c1, c2Copy = c2,
-         c3Copy = c3](sofa::helper::visual::DrawTool* drawTool)
+    struct DrawTriangleVNormVCol : public DrawToolSnapshot
+    {
+        Vec3 m_p1, m_p2, m_p3, m_n1, m_n2, m_n3;
+        RGBAColor m_c1, m_c2, m_c3;
+
+        DrawTriangleVNormVCol(const Vec3& p1, const Vec3& p2, const Vec3& p3,
+                              const Vec3& normal1, const Vec3& normal2, const Vec3& normal3,
+                              const RGBAColor& c1, const RGBAColor& c2, const RGBAColor& c3)
+            : m_p1(p1), m_p2(p2), m_p3(p3), m_n1(normal1), m_n2(normal2), m_n3(normal3),
+              m_c1(c1), m_c2(c2), m_c3(c3) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
         {
-            drawTool->drawTriangle(p1Copy, p2Copy, p3Copy, n1Copy, n2Copy, n3Copy, c1Copy, c2Copy,
-                                   c3Copy);
-        });
+            drawTool->drawTriangle(m_p1, m_p2, m_p3, m_n1, m_n2, m_n3, m_c1, m_c2, m_c3);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawTriangleVNormVCol(p1, p2, p3, normal1, normal2, normal3, c1, c2, c3));
 }
+
 void CaptureSnapshotDrawTool::drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                        const Vec3& p4, const Vec3& normal)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p1Copy = p1, p2Copy = p2, p3Copy = p3, p4Copy = p4,
-         normalCopy = normal](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawQuad(p1Copy, p2Copy, p3Copy, p4Copy, normalCopy); });
+    struct DrawQuad : public DrawToolSnapshot
+    {
+        Vec3 m_p1, m_p2, m_p3, m_p4, m_normal;
+
+        DrawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& p4, const Vec3& normal)
+            : m_p1(p1), m_p2(p2), m_p3(p3), m_p4(p4), m_normal(normal) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawQuad(m_p1, m_p2, m_p3, m_p4, m_normal);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawQuad(p1, p2, p3, p4, normal));
 }
+
 void CaptureSnapshotDrawTool::drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                        const Vec3& p4, const Vec3& normal, const RGBAColor& c)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p1Copy = p1, p2Copy = p2, p3Copy = p3, p4Copy = p4, normalCopy = normal,
-         cCopy = c](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawQuad(p1Copy, p2Copy, p3Copy, p4Copy, normalCopy, cCopy); });
+    struct DrawQuadCol : public DrawToolSnapshot
+    {
+        Vec3 m_p1, m_p2, m_p3, m_p4, m_normal;
+        RGBAColor m_c;
+
+        DrawQuadCol(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& p4, const Vec3& normal, const RGBAColor& c)
+            : m_p1(p1), m_p2(p2), m_p3(p3), m_p4(p4), m_normal(normal), m_c(c) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawQuad(m_p1, m_p2, m_p3, m_p4, m_normal, m_c);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawQuadCol(p1, p2, p3, p4, normal, c));
 }
+
 void CaptureSnapshotDrawTool::drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                        const Vec3& p4, const Vec3& normal, const RGBAColor& c1,
                                        const RGBAColor& c2, const RGBAColor& c3,
                                        const RGBAColor& c4)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p1Copy = p1, p2Copy = p2, p3Copy = p3, p4Copy = p4, normalCopy = normal, c1Copy = c1,
-         c2Copy = c2, c3Copy = c3, c4Copy = c4](sofa::helper::visual::DrawTool* drawTool)
+    struct DrawQuadVCol : public DrawToolSnapshot
+    {
+        Vec3 m_p1, m_p2, m_p3, m_p4, m_normal;
+        RGBAColor m_c1, m_c2, m_c3, m_c4;
+
+        DrawQuadVCol(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& p4, const Vec3& normal,
+                     const RGBAColor& c1, const RGBAColor& c2, const RGBAColor& c3, const RGBAColor& c4)
+            : m_p1(p1), m_p2(p2), m_p3(p3), m_p4(p4), m_normal(normal), m_c1(c1), m_c2(c2), m_c3(c3), m_c4(c4) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
         {
-            drawTool->drawQuad(p1Copy, p2Copy, p3Copy, p4Copy, normalCopy, c1Copy, c2Copy, c3Copy,
-                               c4Copy);
-        });
+            drawTool->drawQuad(m_p1, m_p2, m_p3, m_p4, m_normal, m_c1, m_c2, m_c3, m_c4);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawQuadVCol(p1, p2, p3, p4, normal, c1, c2, c3, c4));
 }
+
 void CaptureSnapshotDrawTool::drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3,
                                        const Vec3& p4, const Vec3& normal1, const Vec3& normal2,
                                        const Vec3& normal3, const Vec3& normal4,
                                        const RGBAColor& c1, const RGBAColor& c2,
                                        const RGBAColor& c3, const RGBAColor& c4)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p1Copy = p1, p2Copy = p2, p3Copy = p3, p4Copy = p4, n1Copy = normal1, n2Copy = normal2,
-         n3Copy = normal3, n4Copy = normal4, c1Copy = c1, c2Copy = c2, c3Copy = c3,
-         c4Copy = c4](sofa::helper::visual::DrawTool* drawTool)
+    struct DrawQuadVNormVCol : public DrawToolSnapshot
+    {
+        Vec3 m_p1, m_p2, m_p3, m_p4, m_n1, m_n2, m_n3, m_n4;
+        RGBAColor m_c1, m_c2, m_c3, m_c4;
+
+        DrawQuadVNormVCol(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& p4,
+                          const Vec3& normal1, const Vec3& normal2, const Vec3& normal3, const Vec3& normal4,
+                          const RGBAColor& c1, const RGBAColor& c2, const RGBAColor& c3, const RGBAColor& c4)
+            : m_p1(p1), m_p2(p2), m_p3(p3), m_p4(p4), m_n1(normal1), m_n2(normal2), m_n3(normal3), m_n4(normal4),
+              m_c1(c1), m_c2(c2), m_c3(c3), m_c4(c4) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
         {
-            drawTool->drawQuad(p1Copy, p2Copy, p3Copy, p4Copy, n1Copy, n2Copy, n3Copy, n4Copy,
-                               c1Copy, c2Copy, c3Copy, c4Copy);
-        });
+            drawTool->drawQuad(m_p1, m_p2, m_p3, m_p4, m_n1, m_n2, m_n3, m_n4, m_c1, m_c2, m_c3, m_c4);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawQuadVNormVCol(p1, p2, p3, p4, normal1, normal2, normal3, normal4, c1, c2, c3, c4));
 }
+
 void CaptureSnapshotDrawTool::drawQuads(const std::vector<Vec3>& points, const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawQuads(pointsCopy, colorCopy); });
+    struct DrawQuads : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        RGBAColor m_color;
+
+        DrawQuads(const std::vector<Vec3>& points, const RGBAColor& color)
+            : m_points(points), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawQuads(m_points, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawQuads(points, color));
 }
+
 void CaptureSnapshotDrawTool::drawQuads(const std::vector<Vec3>& points,
                                         const std::vector<RGBAColor>& colors)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, colorsCopy = colors](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawQuads(pointsCopy, colorsCopy); });
+    struct DrawQuadsCol : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        std::vector<RGBAColor> m_colors;
+
+        DrawQuadsCol(const std::vector<Vec3>& points, const std::vector<RGBAColor>& colors)
+            : m_points(points), m_colors(colors) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawQuads(m_points, m_colors);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawQuadsCol(points, colors));
 }
+
 void CaptureSnapshotDrawTool::drawTetrahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2,
                                               const Vec3& p3, const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p0Copy = p0, p1Copy = p1, p2Copy = p2, p3Copy = p3,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawTetrahedron(p0Copy, p1Copy, p2Copy, p3Copy, colorCopy); });
+    struct DrawTetrahedron : public DrawToolSnapshot
+    {
+        Vec3 m_p0, m_p1, m_p2, m_p3;
+        RGBAColor m_color;
+
+        DrawTetrahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2, const Vec3& p3, const RGBAColor& color)
+            : m_p0(p0), m_p1(p1), m_p2(p2), m_p3(p3), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawTetrahedron(m_p0, m_p1, m_p2, m_p3, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawTetrahedron(p0, p1, p2, p3, color));
 }
+
 void CaptureSnapshotDrawTool::drawScaledTetrahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2,
                                                     const Vec3& p3, const RGBAColor& color,
                                                     const float scale)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p0Copy = p0, p1Copy = p1, p2Copy = p2, p3Copy = p3, colorCopy = color,
-         scaleCopy = scale](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawScaledTetrahedron(p0Copy, p1Copy, p2Copy, p3Copy, colorCopy, scaleCopy); });
+    struct DrawScaledTetrahedron : public DrawToolSnapshot
+    {
+        Vec3 m_p0, m_p1, m_p2, m_p3;
+        RGBAColor m_color;
+        float m_scale;
+
+        DrawScaledTetrahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2, const Vec3& p3, const RGBAColor& color, float scale)
+            : m_p0(p0), m_p1(p1), m_p2(p2), m_p3(p3), m_color(color), m_scale(scale) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawScaledTetrahedron(m_p0, m_p1, m_p2, m_p3, m_color, m_scale);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawScaledTetrahedron(p0, p1, p2, p3, color, scale));
 }
+
 void CaptureSnapshotDrawTool::drawTetrahedra(const std::vector<Vec3>& points,
                                              const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawTetrahedra(pointsCopy, colorCopy); });
+    struct DrawTetrahedra : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        RGBAColor m_color;
+
+        DrawTetrahedra(const std::vector<Vec3>& points, const RGBAColor& color)
+            : m_points(points), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawTetrahedra(m_points, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawTetrahedra(points, color));
 }
+
 void CaptureSnapshotDrawTool::drawScaledTetrahedra(const std::vector<Vec3>& points,
                                                    const RGBAColor& color, const float scale)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, colorCopy = color,
-         scaleCopy = scale](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawScaledTetrahedra(pointsCopy, colorCopy, scaleCopy); });
+    struct DrawScaledTetrahedra : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        RGBAColor m_color;
+        float m_scale;
+
+        DrawScaledTetrahedra(const std::vector<Vec3>& points, const RGBAColor& color, float scale)
+            : m_points(points), m_color(color), m_scale(scale) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawScaledTetrahedra(m_points, m_color, m_scale);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawScaledTetrahedra(points, color, scale));
 }
+
 void CaptureSnapshotDrawTool::drawHexahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2,
                                              const Vec3& p3, const Vec3& p4, const Vec3& p5,
                                              const Vec3& p6, const Vec3& p7, const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [p0Copy = p0, p1Copy = p1, p2Copy = p2, p3Copy = p3, p4Copy = p4, p5Copy = p5, p6Copy = p6,
-         p7Copy = p7, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
+    struct DrawHexahedron : public DrawToolSnapshot
+    {
+        Vec3 m_p0, m_p1, m_p2, m_p3, m_p4, m_p5, m_p6, m_p7;
+        RGBAColor m_color;
+
+        DrawHexahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2, const Vec3& p3,
+                       const Vec3& p4, const Vec3& p5, const Vec3& p6, const Vec3& p7, const RGBAColor& color)
+            : m_p0(p0), m_p1(p1), m_p2(p2), m_p3(p3), m_p4(p4), m_p5(p5), m_p6(p6), m_p7(p7), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
         {
-            drawTool->drawHexahedron(p0Copy, p1Copy, p2Copy, p3Copy, p4Copy, p5Copy, p6Copy, p7Copy,
-                                     colorCopy);
-        });
+            drawTool->drawHexahedron(m_p0, m_p1, m_p2, m_p3, m_p4, m_p5, m_p6, m_p7, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawHexahedron(p0, p1, p2, p3, p4, p5, p6, p7, color));
 }
+
 void CaptureSnapshotDrawTool::drawHexahedra(const std::vector<Vec3>& points, const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawHexahedra(pointsCopy, colorCopy); });
+    struct DrawHexahedra : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        RGBAColor m_color;
+
+        DrawHexahedra(const std::vector<Vec3>& points, const RGBAColor& color)
+            : m_points(points), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawHexahedra(m_points, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawHexahedra(points, color));
 }
+
 void CaptureSnapshotDrawTool::drawScaledHexahedra(const std::vector<Vec3>& points,
                                                   const RGBAColor& color, const float scale)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pointsCopy = points, colorCopy = color,
-         scaleCopy = scale](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawScaledHexahedra(pointsCopy, colorCopy, scaleCopy); });
+    struct DrawScaledHexahedra : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        RGBAColor m_color;
+        float m_scale;
+
+        DrawScaledHexahedra(const std::vector<Vec3>& points, const RGBAColor& color, float scale)
+            : m_points(points), m_color(color), m_scale(scale) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawScaledHexahedra(m_points, m_color, m_scale);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawScaledHexahedra(points, color, scale));
 }
+
 void CaptureSnapshotDrawTool::drawSphere(const Vec3& p, float radius)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pCopy = p, radiusCopy = radius](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawSphere(pCopy, radiusCopy); });
+    struct DrawSphere : public DrawToolSnapshot
+    {
+        Vec3 m_p;
+        float m_radius;
+
+        DrawSphere(const Vec3& p, float radius)
+            : m_p(p), m_radius(radius) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawSphere(m_p, m_radius);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawSphere(p, radius));
 }
+
 void CaptureSnapshotDrawTool::drawSphere(const Vec3& p, float radius, const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back([pCopy = p, radiusCopy = radius, colorCopy = color](
-                                              sofa::helper::visual::DrawTool* drawTool)
-                                          { drawTool->drawSphere(pCopy, radiusCopy, colorCopy); });
+    struct DrawSphereCol : public DrawToolSnapshot
+    {
+        Vec3 m_p;
+        float m_radius;
+        RGBAColor m_color;
+
+        DrawSphereCol(const Vec3& p, float radius, const RGBAColor& color)
+            : m_p(p), m_radius(radius), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawSphere(m_p, m_radius, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawSphereCol(p, radius, color));
 }
+
 void CaptureSnapshotDrawTool::drawEllipsoid(const Vec3& p, const Vec3& radii)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pCopy = p, radiiCopy = radii](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawEllipsoid(pCopy, radiiCopy); });
+    struct DrawEllipsoid : public DrawToolSnapshot
+    {
+        Vec3 m_p, m_radii;
+
+        DrawEllipsoid(const Vec3& p, const Vec3& radii)
+            : m_p(p), m_radii(radii) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawEllipsoid(m_p, m_radii);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawEllipsoid(p, radii));
 }
+
 void CaptureSnapshotDrawTool::drawBoundingBox(const Vec3& min, const Vec3& max, float size)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [minCopy = min, maxCopy = max, sizeCopy = size](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->drawBoundingBox(minCopy, maxCopy, sizeCopy); });
+    struct DrawBoundingBox : public DrawToolSnapshot
+    {
+        Vec3 m_min, m_max;
+        float m_size;
+
+        DrawBoundingBox(const Vec3& min, const Vec3& max, float size)
+            : m_min(min), m_max(max), m_size(size) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawBoundingBox(m_min, m_max, m_size);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawBoundingBox(min, max, size));
 }
+
 void CaptureSnapshotDrawTool::draw3DText(const Vec3& p, float scale, const RGBAColor& color,
                                          const char* text)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [pCopy = p, scaleCopy = scale, colorCopy = color,
-         textCopy = std::string(text)](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->draw3DText(pCopy, scaleCopy, colorCopy, textCopy.c_str()); });
+    struct Draw3DText : public DrawToolSnapshot
+    {
+        Vec3 m_p;
+        float m_scale;
+        RGBAColor m_color;
+        std::string m_text;
+
+        Draw3DText(const Vec3& p, float scale, const RGBAColor& color, const char* text)
+            : m_p(p), m_scale(scale), m_color(color), m_text(text) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->draw3DText(m_p, m_scale, m_color, m_text.c_str());
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new Draw3DText(p, scale, color, text));
 }
+
 void CaptureSnapshotDrawTool::draw3DText_Indices(const std::vector<Vec3>& positions, float scale,
                                                  const RGBAColor& color)
 {
-    m_sceneSnapshot->m_draws.emplace_back(
-        [positionsCopy = positions, scaleCopy = scale,
-         colorCopy = color](sofa::helper::visual::DrawTool* drawTool)
-        { drawTool->draw3DText_Indices(positionsCopy, scaleCopy, colorCopy); });
+    struct Draw3DTextIndices : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_positions;
+        float m_scale;
+        RGBAColor m_color;
+
+        Draw3DTextIndices(const std::vector<Vec3>& positions, float scale, const RGBAColor& color)
+            : m_positions(positions), m_scale(scale), m_color(color) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->draw3DText_Indices(m_positions, m_scale, m_color);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new Draw3DTextIndices(positions, scale, color));
 }
+
 }  // namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.cpp
+++ b/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.cpp
@@ -199,6 +199,26 @@ void CaptureSnapshotDrawTool::drawLineStrip(const std::vector<Vec3>& points, flo
 
     m_sceneSnapshot->m_draws.emplace_back(new DrawLineStrip(points, size, color));
 }
+void CaptureSnapshotDrawTool::drawLineStrip(const std::vector<Vec3>& points, float size,
+                                            const std::vector<RGBAColor>& colors)
+{
+    struct DrawLineStrip : public DrawToolSnapshot
+    {
+        std::vector<Vec3> m_points;
+        float m_size;
+        std::vector<RGBAColor> m_colors;
+
+        DrawLineStrip(const std::vector<Vec3>& points, float size, const std::vector<RGBAColor>& colors)
+            : m_points(points), m_size(size), m_colors(colors) {}
+
+        void draw(sofa::helper::visual::DrawTool* drawTool) const override
+        {
+            drawTool->drawLineStrip(m_points, m_size, m_colors);
+        }
+    };
+
+    m_sceneSnapshot->m_draws.emplace_back(new DrawLineStrip(points, size, colors));
+}
 
 void CaptureSnapshotDrawTool::drawLineLoop(const std::vector<Vec3>& points, float size,
                                            const RGBAColor& color)

--- a/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.h
+++ b/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.h
@@ -52,7 +52,7 @@ public:
                          const RGBAColor& color) override;
     void drawFrame(const Vec3& position, const Quaternion& orientation, const Vec3f& size) override;
     void drawFrame(const Vec3& position, const Quaternion& orientation, const Vec3f& size,
-                   const RGBAColor& color) override{}
+                   const RGBAColor& color) override;
     void drawSpheres(const std::vector<Vec3>& points, const std::vector<float>& radius,
                      const RGBAColor& color) override;
     void drawSpheres(const std::vector<Vec3>& points, float radius,

--- a/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.h
+++ b/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.h
@@ -14,111 +14,111 @@ public:
     explicit CaptureSnapshotDrawTool(std::shared_ptr<SceneSnapshot>& sceneSnapshot);
 
     void init() override{}
-    void drawPoints(const std::vector<Vec3>& points, float size, const RGBAColor& color) override{}
+    void drawPoints(const std::vector<Vec3>& points, float size, const RGBAColor& color) override;
     void drawPoints(const std::vector<Vec3>& points, float size,
-                    const std::vector<RGBAColor>& color) override{}
-    void drawLine(const Vec3& p1, const Vec3& p2, const RGBAColor& color) override{}
+                    const std::vector<RGBAColor>& color) override;
+    void drawLine(const Vec3& p1, const Vec3& p2, const RGBAColor& color) override;
     void drawInfiniteLine(const Vec3& point, const Vec3& direction, const RGBAColor& color,
-                          const bool& vanishing) override{}
+                          const bool& vanishing) override;
     void drawInfiniteLine(const Vec3& point, const Vec3& direction, const float& size,
-                          const RGBAColor& color, const bool& vanishing) override{}
-    void drawLines(const std::vector<Vec3>& points, float size, const RGBAColor& color) override{}
+                          const RGBAColor& color, const bool& vanishing) override;
+    void drawLines(const std::vector<Vec3>& points, float size, const RGBAColor& color) override;
     void drawLines(const std::vector<Vec3>& points, float size,
-                   const std::vector<RGBAColor>& colors) override{}
+                   const std::vector<RGBAColor>& colors) override;
     void drawLines(const std::vector<Vec3>& points, const std::vector<Vec2i>& index, float size,
-                   const RGBAColor& color) override{}
+                   const RGBAColor& color) override;
     void drawLineStrip(const std::vector<Vec3>& points, float size,
-                       const RGBAColor& color) override{}
-    void drawLineLoop(const std::vector<Vec3>& points, float size, const RGBAColor& color) override{}
+                       const RGBAColor& color) override;
+    void drawLineLoop(const std::vector<Vec3>& points, float size, const RGBAColor& color) override;
     void drawDisk(float radius, double from, double to, int resolution,
-                  const RGBAColor& color) override{}
+                  const RGBAColor& color) override;
     void drawCircle(float radius, float lineThickness, int resolution,
-                    const RGBAColor& color) override{}
-    void drawTriangles(const std::vector<Vec3>& points, const RGBAColor& color) override;
+                    const RGBAColor& color) override;
+    auto drawTriangles(const std::vector<Vec3>& points, const RGBAColor& color) -> void override;
     void drawTriangles(const std::vector<Vec3>& points, const Vec3& normal,
-                       const RGBAColor& color) override{}
+                       const RGBAColor& color) override;
     void drawTriangles(const std::vector<Vec3>& points, const std::vector<Vec3i>& index,
-                       const std::vector<Vec3>& normal, const RGBAColor& color) override{}
+                       const std::vector<Vec3>& normal, const RGBAColor& color) override;
     void drawTriangles(const std::vector<Vec3>& points, const std::vector<Vec3i>& index,
                        const std::vector<Vec3>& normal,
-                       const std::vector<RGBAColor>& color) override{}
+                       const std::vector<RGBAColor>& color) override;
     void drawTriangles(const std::vector<Vec3>& points,
-                       const std::vector<RGBAColor>& color) override{}
+                       const std::vector<RGBAColor>& color) override;
     void drawTriangles(const std::vector<Vec3>& points, const std::vector<Vec3>& normal,
-                       const std::vector<RGBAColor>& color) override{}
+                       const std::vector<RGBAColor>& color) override;
     void drawTriangleStrip(const std::vector<Vec3>& points, const std::vector<Vec3>& normal,
-                           const RGBAColor& color) override{}
+                           const RGBAColor& color) override;
     void drawTriangleFan(const std::vector<Vec3>& points, const std::vector<Vec3>& normal,
-                         const RGBAColor& color) override{}
-    void drawFrame(const Vec3& position, const Quaternion& orientation, const Vec3f& size) override{}
+                         const RGBAColor& color) override;
+    void drawFrame(const Vec3& position, const Quaternion& orientation, const Vec3f& size) override;
     void drawFrame(const Vec3& position, const Quaternion& orientation, const Vec3f& size,
                    const RGBAColor& color) override{}
     void drawSpheres(const std::vector<Vec3>& points, const std::vector<float>& radius,
-                     const RGBAColor& color) override{}
+                     const RGBAColor& color) override;
     void drawSpheres(const std::vector<Vec3>& points, float radius,
-                     const RGBAColor& color) override{}
+                     const RGBAColor& color) override;
     void drawFakeSpheres(const std::vector<Vec3>& points, const std::vector<float>& radius,
-                         const RGBAColor& color) override{}
+                         const RGBAColor& color) override;
     void drawFakeSpheres(const std::vector<Vec3>& points, float radius,
-                         const RGBAColor& color) override{}
+                         const RGBAColor& color) override;
     void drawCone(const Vec3& p1, const Vec3& p2, float radius1, float radius2,
-                  const RGBAColor& color, int subd) override{}
-    void drawCube(const float& radius, const RGBAColor& color, const int& subd) override{}
+                  const RGBAColor& color, int subd) override;
+    void drawCube(const float& radius, const RGBAColor& color, const int& subd) override;
     void drawCylinder(const Vec3& p1, const Vec3& p2, float radius, const RGBAColor& color,
-                      int subd) override{}
+                      int subd) override;
     void drawCapsule(const Vec3& p1, const Vec3& p2, float radius, const RGBAColor& color,
-                     int subd) override{}
+                     int subd) override;
     void drawArrow(const Vec3& p1, const Vec3& p2, float radius, const RGBAColor& color,
-                   int subd) override{}
+                   int subd) override;
     void drawArrow(const Vec3& p1, const Vec3& p2, float radius, float coneLength,
-                   const RGBAColor& color, int subd) override{}
+                   const RGBAColor& color, int subd) override;
     void drawArrow(const Vec3& p1, const Vec3& p2, float radius, float coneLength, float coneRadius,
-                   const RGBAColor& color, int subd) override{}
-    void drawCross(const Vec3& p, float length, const RGBAColor& color) override{}
-    void drawPlus(const float& radius, const RGBAColor& color, const int& subd) override{}
-    void drawPoint(const Vec3& p, const RGBAColor& c) override{}
-    void drawPoint(const Vec3& p, const Vec3& n, const RGBAColor& c) override{}
-    void drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& normal) override{}
+                   const RGBAColor& color, int subd) override;
+    void drawCross(const Vec3& p, float length, const RGBAColor& color) override;
+    void drawPlus(const float& radius, const RGBAColor& color, const int& subd) override;
+    void drawPoint(const Vec3& p, const RGBAColor& c) override;
+    void drawPoint(const Vec3& p, const Vec3& n, const RGBAColor& c) override;
+    void drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& normal) override;
     void drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& normal,
-                      const RGBAColor& c) override{}
+                      const RGBAColor& c) override;
     void drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& normal,
-                      const RGBAColor& c1, const RGBAColor& c2, const RGBAColor& c3) override{}
+                      const RGBAColor& c1, const RGBAColor& c2, const RGBAColor& c3) override;
     void drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& normal1,
                       const Vec3& normal2, const Vec3& normal3, const RGBAColor& c1,
-                      const RGBAColor& c2, const RGBAColor& c3) override{}
+                      const RGBAColor& c2, const RGBAColor& c3) override;
     void drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& p4,
-                  const Vec3& normal) override{}
+                  const Vec3& normal) override;
     void drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& p4,
-                  const Vec3& normal, const RGBAColor& c) override{}
+                  const Vec3& normal, const RGBAColor& c) override;
     void drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& p4,
                   const Vec3& normal, const RGBAColor& c1, const RGBAColor& c2, const RGBAColor& c3,
-                  const RGBAColor& c4) override{}
+                  const RGBAColor& c4) override;
     void drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& p4,
                   const Vec3& normal1, const Vec3& normal2, const Vec3& normal3,
                   const Vec3& normal4, const RGBAColor& c1, const RGBAColor& c2,
-                  const RGBAColor& c3, const RGBAColor& c4) override{}
-    void drawQuads(const std::vector<Vec3>& points, const RGBAColor& color) override{}
-    void drawQuads(const std::vector<Vec3>& points, const std::vector<RGBAColor>& colors) override{}
+                  const RGBAColor& c3, const RGBAColor& c4) override;
+    void drawQuads(const std::vector<Vec3>& points, const RGBAColor& color) override;
+    void drawQuads(const std::vector<Vec3>& points, const std::vector<RGBAColor>& colors) override;
     void drawTetrahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2, const Vec3& p3,
-                         const RGBAColor& color) override{}
+                         const RGBAColor& color) override;
     void drawScaledTetrahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2, const Vec3& p3,
-                               const RGBAColor& color, const float scale) override{}
-    void drawTetrahedra(const std::vector<Vec3>& points, const RGBAColor& color) override{}
+                               const RGBAColor& color, const float scale) override;
+    void drawTetrahedra(const std::vector<Vec3>& points, const RGBAColor& color) override;
     void drawScaledTetrahedra(const std::vector<Vec3>& points, const RGBAColor& color,
-                              const float scale) override{}
+                              const float scale) override;
     void drawHexahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2, const Vec3& p3,
                         const Vec3& p4, const Vec3& p5, const Vec3& p6, const Vec3& p7,
-                        const RGBAColor& color) override{}
-    void drawHexahedra(const std::vector<Vec3>& points, const RGBAColor& color) override{}
+                        const RGBAColor& color) override;
+    void drawHexahedra(const std::vector<Vec3>& points, const RGBAColor& color) override;
     void drawScaledHexahedra(const std::vector<Vec3>& points, const RGBAColor& color,
-                             const float scale) override{}
-    void drawSphere(const Vec3& p, float radius) override{}
-    void drawSphere(const Vec3& p, float radius, const RGBAColor& color) override{}
-    void drawEllipsoid(const Vec3& p, const Vec3& radii) override{}
-    void drawBoundingBox(const Vec3& min, const Vec3& max, float size) override{}
-    void draw3DText(const Vec3& p, float scale, const RGBAColor& color, const char* text) override{}
+                             const float scale) override;
+    void drawSphere(const Vec3& p, float radius) override;
+    void drawSphere(const Vec3& p, float radius, const RGBAColor& color) override;
+    void drawEllipsoid(const Vec3& p, const Vec3& radii) override;
+    void drawBoundingBox(const Vec3& min, const Vec3& max, float size) override;
+    void draw3DText(const Vec3& p, float scale, const RGBAColor& color, const char* text) override;
     void draw3DText_Indices(const std::vector<Vec3>& positions, float scale,
-                            const RGBAColor& color) override{}
+                            const RGBAColor& color) override;
     void pushMatrix() override{}
     void popMatrix() override{}
     void multMatrix(float*) override{}

--- a/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.h
+++ b/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.h
@@ -29,6 +29,8 @@ public:
                    const RGBAColor& color) override;
     void drawLineStrip(const std::vector<Vec3>& points, float size,
                        const RGBAColor& color) override;
+    void drawLineStrip(const std::vector<Vec3>& points, float size,
+                       const std::vector<RGBAColor>& colors) override;
     void drawLineLoop(const std::vector<Vec3>& points, float size, const RGBAColor& color) override;
     void drawDisk(float radius, double from, double to, int resolution,
                   const RGBAColor& color) override;

--- a/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.h
+++ b/SofaGLFW/src/SofaGLFW/CaptureSnapshotDrawTool.h
@@ -1,0 +1,148 @@
+#pragma once
+#include <SofaGLFW/config.h>
+#include <sofa/helper/visual/DrawTool.h>
+
+#include "SceneSnapshot.h"
+
+namespace sofaglfw
+{
+
+class SOFAGLFW_API CaptureSnapshotDrawTool : public sofa::helper::visual::DrawTool
+{
+    std::shared_ptr<SceneSnapshot> m_sceneSnapshot;
+public:
+    explicit CaptureSnapshotDrawTool(std::shared_ptr<SceneSnapshot>& sceneSnapshot);
+
+    void init() override{}
+    void drawPoints(const std::vector<Vec3>& points, float size, const RGBAColor& color) override{}
+    void drawPoints(const std::vector<Vec3>& points, float size,
+                    const std::vector<RGBAColor>& color) override{}
+    void drawLine(const Vec3& p1, const Vec3& p2, const RGBAColor& color) override{}
+    void drawInfiniteLine(const Vec3& point, const Vec3& direction, const RGBAColor& color,
+                          const bool& vanishing) override{}
+    void drawInfiniteLine(const Vec3& point, const Vec3& direction, const float& size,
+                          const RGBAColor& color, const bool& vanishing) override{}
+    void drawLines(const std::vector<Vec3>& points, float size, const RGBAColor& color) override{}
+    void drawLines(const std::vector<Vec3>& points, float size,
+                   const std::vector<RGBAColor>& colors) override{}
+    void drawLines(const std::vector<Vec3>& points, const std::vector<Vec2i>& index, float size,
+                   const RGBAColor& color) override{}
+    void drawLineStrip(const std::vector<Vec3>& points, float size,
+                       const RGBAColor& color) override{}
+    void drawLineLoop(const std::vector<Vec3>& points, float size, const RGBAColor& color) override{}
+    void drawDisk(float radius, double from, double to, int resolution,
+                  const RGBAColor& color) override{}
+    void drawCircle(float radius, float lineThickness, int resolution,
+                    const RGBAColor& color) override{}
+    void drawTriangles(const std::vector<Vec3>& points, const RGBAColor& color) override;
+    void drawTriangles(const std::vector<Vec3>& points, const Vec3& normal,
+                       const RGBAColor& color) override{}
+    void drawTriangles(const std::vector<Vec3>& points, const std::vector<Vec3i>& index,
+                       const std::vector<Vec3>& normal, const RGBAColor& color) override{}
+    void drawTriangles(const std::vector<Vec3>& points, const std::vector<Vec3i>& index,
+                       const std::vector<Vec3>& normal,
+                       const std::vector<RGBAColor>& color) override{}
+    void drawTriangles(const std::vector<Vec3>& points,
+                       const std::vector<RGBAColor>& color) override{}
+    void drawTriangles(const std::vector<Vec3>& points, const std::vector<Vec3>& normal,
+                       const std::vector<RGBAColor>& color) override{}
+    void drawTriangleStrip(const std::vector<Vec3>& points, const std::vector<Vec3>& normal,
+                           const RGBAColor& color) override{}
+    void drawTriangleFan(const std::vector<Vec3>& points, const std::vector<Vec3>& normal,
+                         const RGBAColor& color) override{}
+    void drawFrame(const Vec3& position, const Quaternion& orientation, const Vec3f& size) override{}
+    void drawFrame(const Vec3& position, const Quaternion& orientation, const Vec3f& size,
+                   const RGBAColor& color) override{}
+    void drawSpheres(const std::vector<Vec3>& points, const std::vector<float>& radius,
+                     const RGBAColor& color) override{}
+    void drawSpheres(const std::vector<Vec3>& points, float radius,
+                     const RGBAColor& color) override{}
+    void drawFakeSpheres(const std::vector<Vec3>& points, const std::vector<float>& radius,
+                         const RGBAColor& color) override{}
+    void drawFakeSpheres(const std::vector<Vec3>& points, float radius,
+                         const RGBAColor& color) override{}
+    void drawCone(const Vec3& p1, const Vec3& p2, float radius1, float radius2,
+                  const RGBAColor& color, int subd) override{}
+    void drawCube(const float& radius, const RGBAColor& color, const int& subd) override{}
+    void drawCylinder(const Vec3& p1, const Vec3& p2, float radius, const RGBAColor& color,
+                      int subd) override{}
+    void drawCapsule(const Vec3& p1, const Vec3& p2, float radius, const RGBAColor& color,
+                     int subd) override{}
+    void drawArrow(const Vec3& p1, const Vec3& p2, float radius, const RGBAColor& color,
+                   int subd) override{}
+    void drawArrow(const Vec3& p1, const Vec3& p2, float radius, float coneLength,
+                   const RGBAColor& color, int subd) override{}
+    void drawArrow(const Vec3& p1, const Vec3& p2, float radius, float coneLength, float coneRadius,
+                   const RGBAColor& color, int subd) override{}
+    void drawCross(const Vec3& p, float length, const RGBAColor& color) override{}
+    void drawPlus(const float& radius, const RGBAColor& color, const int& subd) override{}
+    void drawPoint(const Vec3& p, const RGBAColor& c) override{}
+    void drawPoint(const Vec3& p, const Vec3& n, const RGBAColor& c) override{}
+    void drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& normal) override{}
+    void drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& normal,
+                      const RGBAColor& c) override{}
+    void drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& normal,
+                      const RGBAColor& c1, const RGBAColor& c2, const RGBAColor& c3) override{}
+    void drawTriangle(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& normal1,
+                      const Vec3& normal2, const Vec3& normal3, const RGBAColor& c1,
+                      const RGBAColor& c2, const RGBAColor& c3) override{}
+    void drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& p4,
+                  const Vec3& normal) override{}
+    void drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& p4,
+                  const Vec3& normal, const RGBAColor& c) override{}
+    void drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& p4,
+                  const Vec3& normal, const RGBAColor& c1, const RGBAColor& c2, const RGBAColor& c3,
+                  const RGBAColor& c4) override{}
+    void drawQuad(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& p4,
+                  const Vec3& normal1, const Vec3& normal2, const Vec3& normal3,
+                  const Vec3& normal4, const RGBAColor& c1, const RGBAColor& c2,
+                  const RGBAColor& c3, const RGBAColor& c4) override{}
+    void drawQuads(const std::vector<Vec3>& points, const RGBAColor& color) override{}
+    void drawQuads(const std::vector<Vec3>& points, const std::vector<RGBAColor>& colors) override{}
+    void drawTetrahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2, const Vec3& p3,
+                         const RGBAColor& color) override{}
+    void drawScaledTetrahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2, const Vec3& p3,
+                               const RGBAColor& color, const float scale) override{}
+    void drawTetrahedra(const std::vector<Vec3>& points, const RGBAColor& color) override{}
+    void drawScaledTetrahedra(const std::vector<Vec3>& points, const RGBAColor& color,
+                              const float scale) override{}
+    void drawHexahedron(const Vec3& p0, const Vec3& p1, const Vec3& p2, const Vec3& p3,
+                        const Vec3& p4, const Vec3& p5, const Vec3& p6, const Vec3& p7,
+                        const RGBAColor& color) override{}
+    void drawHexahedra(const std::vector<Vec3>& points, const RGBAColor& color) override{}
+    void drawScaledHexahedra(const std::vector<Vec3>& points, const RGBAColor& color,
+                             const float scale) override{}
+    void drawSphere(const Vec3& p, float radius) override{}
+    void drawSphere(const Vec3& p, float radius, const RGBAColor& color) override{}
+    void drawEllipsoid(const Vec3& p, const Vec3& radii) override{}
+    void drawBoundingBox(const Vec3& min, const Vec3& max, float size) override{}
+    void draw3DText(const Vec3& p, float scale, const RGBAColor& color, const char* text) override{}
+    void draw3DText_Indices(const std::vector<Vec3>& positions, float scale,
+                            const RGBAColor& color) override{}
+    void pushMatrix() override{}
+    void popMatrix() override{}
+    void multMatrix(float*) override{}
+    void scale(float) override{}
+    void translate(float x, float y, float z) override{}
+    void setMaterial(const RGBAColor& color) override{}
+    void resetMaterial(const RGBAColor& color) override{}
+    void resetMaterial() override{}
+    void setPolygonMode(int _mode, bool _wireframe) override{}
+    void setLightingEnabled(bool _isAnabled) override{}
+    void enableBlending() override{}
+    void disableBlending() override{}
+    void enableLighting() override{}
+    void disableLighting() override{}
+    void enableDepthTest() override{}
+    void disableDepthTest() override{}
+    void saveLastState() override{}
+    void restoreLastState() override{}
+    void writeOverlayText(int x, int y, unsigned fontSize, const RGBAColor& color,
+                          const char* text) override{}
+    void enablePolygonOffset(float factor, float units) override{}
+    void disablePolygonOffset() override{}
+    void readPixels(int x, int y, int w, int h, float* rgb, float* z) override{}
+};
+
+
+}

--- a/SofaGLFW/src/SofaGLFW/SceneSnapshot.cpp
+++ b/SofaGLFW/src/SofaGLFW/SceneSnapshot.cpp
@@ -1,0 +1,15 @@
+#include <SofaGLFW/SceneSnapshot.h>
+
+namespace sofaglfw
+{
+
+void SceneSnapshot::draw(sofa::helper::visual::DrawTool* drawTool) const
+{
+    for (const auto& draw : m_draws)
+    {
+        draw(drawTool);
+    }
+}
+std::atomic<std::shared_ptr<const SceneSnapshot>> g_currentSceneSnapshot;
+
+}

--- a/SofaGLFW/src/SofaGLFW/SceneSnapshot.cpp
+++ b/SofaGLFW/src/SofaGLFW/SceneSnapshot.cpp
@@ -5,9 +5,9 @@ namespace sofaglfw
 
 void SceneSnapshot::draw(sofa::helper::visual::DrawTool* drawTool) const
 {
-    for (const auto& draw : m_draws)
+    for (const auto& snapshot : m_draws)
     {
-        draw(drawTool);
+        snapshot->draw(drawTool);
     }
 }
 std::atomic<std::shared_ptr<const SceneSnapshot>> g_currentSceneSnapshot;

--- a/SofaGLFW/src/SofaGLFW/SceneSnapshot.h
+++ b/SofaGLFW/src/SofaGLFW/SceneSnapshot.h
@@ -11,11 +11,17 @@
 namespace sofaglfw
 {
 
+struct SOFAGLFW_API DrawToolSnapshot
+{
+    virtual ~DrawToolSnapshot() = default;
+    virtual void draw(sofa::helper::visual::DrawTool* drawTool) const = 0;
+};
+
 
 class SOFAGLFW_API SceneSnapshot
 {
 public:
-    std::vector<std::function<void(sofa::helper::visual::DrawTool*)>> m_draws;
+    std::vector<std::shared_ptr<DrawToolSnapshot>> m_draws;
     sofa::type::BoundingBox m_bbox;
 
 public:

--- a/SofaGLFW/src/SofaGLFW/SceneSnapshot.h
+++ b/SofaGLFW/src/SofaGLFW/SceneSnapshot.h
@@ -1,0 +1,27 @@
+
+#pragma once
+#include <SofaGLFW/config.h>
+#include <sofa/helper/visual/DrawTool.h>
+#include <sofa/type/BoundingBox.h>
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace sofaglfw
+{
+
+
+class SOFAGLFW_API SceneSnapshot
+{
+public:
+    std::vector<std::function<void(sofa::helper::visual::DrawTool*)>> m_draws;
+    sofa::type::BoundingBox m_bbox;
+
+public:
+    void draw(sofa::helper::visual::DrawTool* drawTool) const;
+};
+
+extern SOFAGLFW_API std::atomic<std::shared_ptr<const SceneSnapshot>> g_currentSceneSnapshot;
+
+}

--- a/SofaGLFW/src/SofaGLFW/SimulationLoop.cpp
+++ b/SofaGLFW/src/SofaGLFW/SimulationLoop.cpp
@@ -1,4 +1,26 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
 #include <SofaGLFW/SimulationLoop.h>
+#include <sofa/helper/AdvancedTimer.h>
 
 namespace sofaglfw
 {
@@ -8,7 +30,7 @@ SimulationLoop::~SimulationLoop()
     terminate();
 }
 
-bool SimulationLoop::simulationIsRunning()
+bool SimulationLoop::simulationIsRunning() const
 {
     if (this->groot)
     {
@@ -18,7 +40,7 @@ bool SimulationLoop::simulationIsRunning()
     return false;
 }
 
-void SimulationLoop::step()
+void SimulationLoop::step() const
 {
     if (simulationIsRunning())
     {
@@ -30,7 +52,8 @@ void SimulationLoop::step()
         sofa::helper::AdvancedTimer::end("Animate");
     }
 }
-void SimulationLoop::loop()
+
+void SimulationLoop::loop() const
 {
     while (m_running)
     {

--- a/SofaGLFW/src/SofaGLFW/SimulationLoop.cpp
+++ b/SofaGLFW/src/SofaGLFW/SimulationLoop.cpp
@@ -1,0 +1,60 @@
+#include <SofaGLFW/SimulationLoop.h>
+
+namespace sofaglfw
+{
+
+SimulationLoop::~SimulationLoop()
+{
+    terminate();
+}
+
+bool SimulationLoop::simulationIsRunning()
+{
+    if (this->groot)
+    {
+        return this->groot->getAnimate();
+    }
+
+    return false;
+}
+
+void SimulationLoop::step()
+{
+    if (simulationIsRunning())
+    {
+        sofa::helper::AdvancedTimer::begin("Animate");
+
+        sofa::simulation::node::animate(this->groot.get(), this->groot->getDt());
+        sofa::simulation::node::updateVisual(this->groot.get());
+
+        sofa::helper::AdvancedTimer::end("Animate");
+    }
+}
+void SimulationLoop::loop()
+{
+    while (m_running)
+    {
+        SIMULATION_LOOP_SCOPE
+
+        step();
+    }
+}
+void SimulationLoop::start()
+{
+    if (!m_thread)
+    {
+        m_running = true;
+        m_thread = std::make_unique<std::thread>([this](){ this->loop(); });
+    }
+}
+
+void SimulationLoop::terminate()
+{
+    m_running = false;
+    if (m_thread)
+    {
+        m_thread->join();
+    }
+}
+
+}  // namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/SimulationLoop.cpp
+++ b/SofaGLFW/src/SofaGLFW/SimulationLoop.cpp
@@ -20,7 +20,11 @@
 * Contact information: contact@sofa-framework.org                             *
 ******************************************************************************/
 #include <SofaGLFW/SimulationLoop.h>
+#include <sofa/core/visual/VisualParams.h>
 #include <sofa/helper/AdvancedTimer.h>
+
+#include "CaptureSnapshotDrawTool.h"
+#include "SceneSnapshot.h"
 
 namespace sofaglfw
 {
@@ -49,6 +53,8 @@ void SimulationLoop::step() const
         sofa::simulation::node::animate(this->groot.get(), this->groot->getDt());
         sofa::simulation::node::updateVisual(this->groot.get());
 
+        commitVisual();
+
         sofa::helper::AdvancedTimer::end("Animate");
     }
 }
@@ -58,7 +64,6 @@ void SimulationLoop::loop() const
     while (m_running)
     {
         SIMULATION_LOOP_SCOPE
-
         step();
     }
 }
@@ -67,7 +72,13 @@ void SimulationLoop::start()
     if (!m_thread)
     {
         m_running = true;
-        m_thread = std::make_unique<std::thread>([this](){ this->loop(); });
+
+        this->commitVisual();
+
+        m_thread = std::make_unique<std::thread>([this]()
+        {
+            this->loop();
+        });
     }
 }
 
@@ -77,7 +88,33 @@ void SimulationLoop::terminate()
     if (m_thread)
     {
         m_thread->join();
+        m_thread = nullptr;
     }
+}
+
+void SimulationLoop::captureVisualizationData(std::shared_ptr<SceneSnapshot> newScene) const
+{
+    CaptureSnapshotDrawTool drawTool(newScene);
+
+    auto vparams = sofa::core::visual::VisualParams::defaultInstance();
+
+    sofa::helper::visual::DrawTool* currentDrawTool{vparams->drawTool()};
+    vparams->drawTool() = &drawTool;
+
+    sofa::simulation::node::draw(vparams, this->groot.get());
+
+    vparams->drawTool() = currentDrawTool;
+}
+
+void SimulationLoop::commitVisual() const
+{
+    auto newScene = std::make_shared<SceneSnapshot>();
+    newScene->m_bbox = this->groot->f_bbox.getValue();
+
+    captureVisualizationData(newScene);
+
+    // update the newly created snapshot
+    g_currentSceneSnapshot.store(newScene, std::memory_order_release);
 }
 
 }  // namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/SimulationLoop.cpp
+++ b/SofaGLFW/src/SofaGLFW/SimulationLoop.cpp
@@ -44,8 +44,20 @@ bool SimulationLoop::simulationIsRunning() const
     return false;
 }
 
-void SimulationLoop::step() const
+void SimulationLoop::step()
 {
+    {
+        std::vector<std::function<void()>> commands;
+        {
+            std::lock_guard<std::mutex> lock(m_commandQueueMutex);
+            commands.swap(m_commandQueue);
+        }
+        for (const auto& command : commands)
+        {
+            command();
+        }
+    }
+
     if (simulationIsRunning())
     {
         sofa::helper::AdvancedTimer::begin("Animate");
@@ -59,7 +71,7 @@ void SimulationLoop::step() const
     }
 }
 
-void SimulationLoop::loop() const
+void SimulationLoop::loop()
 {
     while (m_running)
     {
@@ -90,6 +102,12 @@ void SimulationLoop::terminate()
         m_thread->join();
         m_thread = nullptr;
     }
+}
+
+void SimulationLoop::pushCommand(std::function<void()> command)
+{
+    std::lock_guard<std::mutex> lock(m_commandQueueMutex);
+    m_commandQueue.emplace_back(std::move(command));
 }
 
 void SimulationLoop::captureVisualizationData(std::shared_ptr<SceneSnapshot> newScene) const

--- a/SofaGLFW/src/SofaGLFW/SimulationLoop.cpp
+++ b/SofaGLFW/src/SofaGLFW/SimulationLoop.cpp
@@ -60,6 +60,22 @@ void SimulationLoop::step()
 
     if (simulationIsRunning())
     {
+        auto now = std::chrono::steady_clock::now();
+        if (m_lastStepTime.time_since_epoch().count() > 0)
+        {
+            float deltaTime = std::chrono::duration<float>(now - m_lastStepTime).count();
+            m_framerateAccum += deltaTime;
+            m_framerateCount++;
+
+            if (m_framerateAccum >= 0.5f) // Update every 0.5 seconds
+            {
+                m_physicsFramerate.store(static_cast<float>(m_framerateCount) / m_framerateAccum, std::memory_order_relaxed);
+                m_framerateAccum = 0.0f;
+                m_framerateCount = 0;
+            }
+        }
+        m_lastStepTime = now;
+
         sofa::helper::AdvancedTimer::begin("Animate");
 
         sofa::simulation::node::animate(this->groot.get(), this->groot->getDt());
@@ -108,6 +124,11 @@ void SimulationLoop::pushCommand(std::function<void()> command)
 {
     std::lock_guard<std::mutex> lock(m_commandQueueMutex);
     m_commandQueue.emplace_back(std::move(command));
+}
+
+float SimulationLoop::getPhysicsFramerate() const
+{
+    return m_physicsFramerate.load(std::memory_order_relaxed);
 }
 
 void SimulationLoop::captureVisualizationData(std::shared_ptr<SceneSnapshot> newScene) const

--- a/SofaGLFW/src/SofaGLFW/SimulationLoop.h
+++ b/SofaGLFW/src/SofaGLFW/SimulationLoop.h
@@ -21,12 +21,14 @@
 ******************************************************************************/
 #pragma once
 #include <SofaGLFW/config.h>
-
 #include <sofa/simulation/Node.h>
 #include <sofa/simulation/Simulation.h>
 #include <sofa/simulation/SimulationLoop.h>
 
+#include <shared_mutex>
 #include <thread>
+
+#include "SceneSnapshot.h"
 
 namespace sofaglfw
 {
@@ -35,6 +37,8 @@ class SOFAGLFW_API SimulationLoop
 {
 public:
 
+    using Mutex = std::shared_mutex;
+
     ~SimulationLoop();
 
     /// the sofa root note of the current scene
@@ -42,17 +46,22 @@ public:
 
     bool simulationIsRunning() const;
 
+
     void step() const;
 
     void loop() const;
 
     void start();
     void terminate();
+    void captureVisualizationData(std::shared_ptr<SceneSnapshot> newScene) const;
 
-private:
+   private:
 
     std::atomic<bool> m_running { false };
     std::unique_ptr<std::thread> m_thread;
+
+
+    void commitVisual() const;
 };
 
 

--- a/SofaGLFW/src/SofaGLFW/SimulationLoop.h
+++ b/SofaGLFW/src/SofaGLFW/SimulationLoop.h
@@ -21,7 +21,7 @@
 ******************************************************************************/
 #pragma once
 #include <SofaGLFW/config.h>
-#include <sofa/helper/AdvancedTimer.h>
+
 #include <sofa/simulation/Node.h>
 #include <sofa/simulation/Simulation.h>
 #include <sofa/simulation/SimulationLoop.h>
@@ -40,18 +40,18 @@ public:
     /// the sofa root note of the current scene
     sofa::simulation::Node::SPtr groot;
 
-    bool simulationIsRunning();
+    bool simulationIsRunning() const;
 
-    void step();
+    void step() const;
 
-    void loop();
+    void loop() const;
 
     void start();
     void terminate();
 
 private:
 
-    bool m_running { false };
+    std::atomic<bool> m_running { false };
     std::unique_ptr<std::thread> m_thread;
 };
 

--- a/SofaGLFW/src/SofaGLFW/SimulationLoop.h
+++ b/SofaGLFW/src/SofaGLFW/SimulationLoop.h
@@ -1,0 +1,59 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU General Public License as published by the Free  *
+* Software Foundation; either version 2 of the License, or (at your option)   *
+* any later version.                                                          *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for    *
+* more details.                                                               *
+*                                                                             *
+* You should have received a copy of the GNU General Public License along     *
+* with this program. If not, see <http://www.gnu.org/licenses/>.              *
+*******************************************************************************
+* Authors: The SOFA Team and external contributors (see Authors.txt)          *
+*                                                                             *
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+#pragma once
+#include <SofaGLFW/config.h>
+#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/simulation/Node.h>
+#include <sofa/simulation/Simulation.h>
+#include <sofa/simulation/SimulationLoop.h>
+
+#include <thread>
+
+namespace sofaglfw
+{
+
+class SOFAGLFW_API SimulationLoop
+{
+public:
+
+    ~SimulationLoop();
+
+    /// the sofa root note of the current scene
+    sofa::simulation::Node::SPtr groot;
+
+    bool simulationIsRunning();
+
+    void step();
+
+    void loop();
+
+    void start();
+    void terminate();
+
+private:
+
+    bool m_running { false };
+    std::unique_ptr<std::thread> m_thread;
+};
+
+
+}

--- a/SofaGLFW/src/SofaGLFW/SimulationLoop.h
+++ b/SofaGLFW/src/SofaGLFW/SimulationLoop.h
@@ -25,8 +25,12 @@
 #include <sofa/simulation/Simulation.h>
 #include <sofa/simulation/SimulationLoop.h>
 
+#include <atomic>
+#include <functional>
+#include <mutex>
 #include <shared_mutex>
 #include <thread>
+#include <vector>
 
 #include "SceneSnapshot.h"
 
@@ -47,13 +51,19 @@ public:
     bool simulationIsRunning() const;
 
 
-    void step() const;
+    void step();
 
-    void loop() const;
+    void loop();
 
     void start();
     void terminate();
     void captureVisualizationData(std::shared_ptr<SceneSnapshot> newScene) const;
+
+    /**
+     * @brief Push a command to be executed at the beginning of the next simulation step.
+     * @param command The command to execute.
+     */
+    void pushCommand(std::function<void()> command);
 
    private:
 
@@ -62,6 +72,9 @@ public:
 
 
     void commitVisual() const;
+
+    std::vector<std::function<void()>> m_commandQueue;
+    std::mutex m_commandQueueMutex;
 };
 
 

--- a/SofaGLFW/src/SofaGLFW/SimulationLoop.h
+++ b/SofaGLFW/src/SofaGLFW/SimulationLoop.h
@@ -26,6 +26,7 @@
 #include <sofa/simulation/SimulationLoop.h>
 
 #include <atomic>
+#include <chrono>
 #include <functional>
 #include <mutex>
 #include <shared_mutex>
@@ -59,6 +60,8 @@ public:
     void terminate();
     void captureVisualizationData(std::shared_ptr<SceneSnapshot> newScene) const;
 
+    float getPhysicsFramerate() const;
+
     /**
      * @brief Push a command to be executed at the beginning of the next simulation step.
      * @param command The command to execute.
@@ -70,6 +73,10 @@ public:
     std::atomic<bool> m_running { false };
     std::unique_ptr<std::thread> m_thread;
 
+    mutable std::atomic<float> m_physicsFramerate { 0.0f };
+    std::chrono::steady_clock::time_point m_lastStepTime;
+    float m_framerateAccum { 0.0f };
+    int m_framerateCount { 0 };
 
     void commitVisual() const;
 

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -23,36 +23,34 @@
 
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
-
+#include <SofaGLFW/SofaGLFWMouseManager.h>
 #include <SofaGLFW/SofaGLFWWindow.h>
 #include <SofaGLFW/config.h>
-
-#include <SofaGLFW/SofaGLFWMouseManager.h>
-
-#include <sofa/helper/logging/Messaging.h>
-#include <sofa/helper/AdvancedTimer.h>
-#include <sofa/helper/io/STBImage.h>
-#include <sofa/helper/system/FileRepository.h>
-#include <sofa/helper/system/FileSystem.h>
-#include <sofa/core/visual/VisualParams.h>
+#include <sofa/component/visual/LineAxis.h>
+#include <sofa/component/visual/VisualStyle.h>
 #include <sofa/core/objectmodel/BaseClassNameHelper.h>
 #include <sofa/core/objectmodel/KeypressedEvent.h>
 #include <sofa/core/objectmodel/KeyreleasedEvent.h>
+#include <sofa/core/visual/VisualParams.h>
+#include <sofa/gui/common/BaseGUI.h>
+#include <sofa/gui/common/BaseViewer.h>
+#include <sofa/gui/common/PickHandler.h>
+#include <sofa/helper/AdvancedTimer.h>
+#include <sofa/helper/Utils.h>
+#include <sofa/helper/io/STBImage.h>
+#include <sofa/helper/logging/Messaging.h>
+#include <sofa/helper/system/FileRepository.h>
+#include <sofa/helper/system/FileSystem.h>
+#include <sofa/helper/system/SetDirectory.h>
 #include <sofa/simulation/Node.h>
 #include <sofa/simulation/Simulation.h>
 #include <sofa/simulation/SimulationLoop.h>
-#include <sofa/component/visual/VisualStyle.h>
-#include <sofa/component/visual/LineAxis.h>
-#include <sofa/gui/common/BaseViewer.h>
-#include <sofa/gui/common/BaseGUI.h>
-#include <sofa/gui/common/PickHandler.h>
-
-#include <sofa/helper/system/SetDirectory.h>
-#include <sofa/helper/Utils.h>
 
 #include <algorithm>
 #include <filesystem>
 #include <map>
+
+#include "SceneSnapshot.h"
 
 using namespace sofa;
 using namespace sofa::gui::common;
@@ -460,7 +458,7 @@ void SofaGLFWBaseGUI::setWindowTitle(GLFWwindow* window, const char* title)
 void SofaGLFWBaseGUI::makeCurrentContext(GLFWwindow* glfwWindow)
 {
     glfwMakeContextCurrent(glfwWindow);
-    glfwSwapInterval( 0 ); //request disabling vsync
+    glfwSwapInterval( 1 ); //request enabling vsync
     if (!m_bGlewIsInitialized)
     {
         glewInit();
@@ -499,7 +497,11 @@ std::size_t SofaGLFWBaseGUI::runLoop(std::size_t targetNbIterations)
                     makeCurrentContext(glfwWindow);
                     
                     m_guiEngine->beforeDraw(glfwWindow);
-                    sofaGlfwWindow->draw(this->groot, m_vparams);
+
+                    if (auto scene = g_currentSceneSnapshot.load(std::memory_order_acquire))
+                    {
+                        sofaGlfwWindow->draw(*scene, this->m_glDrawTool.get());
+                    }
 
                     drawSelection(m_vparams);
 

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -525,6 +525,8 @@ std::size_t SofaGLFWBaseGUI::runLoop(std::size_t targetNbIterations)
                 }
                 else
                 {
+                    m_simulationLoop.terminate();
+
                     // otherwise close this window
                     closedWindows.emplace_back(glfwWindow, sofaGlfwWindow);
                 }

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -621,6 +621,8 @@ void SofaGLFWBaseGUI::terminate()
     if (!m_bGlfwIsInitialized)
         return;
 
+    m_simulationLoop.terminate();
+
     if (m_guiEngine)
         m_guiEngine->terminate();
 

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -137,6 +137,9 @@ void SofaGLFWBaseGUI::setSimulation(NodeSPtr groot, const std::string& filename)
 
     if (this->groot)
     {
+        m_simulationLoop.groot = groot;
+        m_simulationLoop.start();
+
         // Initialize the pick handler
         this->pick->init(this->groot.get());
         m_sofaGLFWMouseManager.setPickHandler(getPickHandler());
@@ -484,10 +487,6 @@ std::size_t SofaGLFWBaseGUI::runLoop(std::size_t targetNbIterations)
 
     while (s_numberOfActiveWindows > 0 && running)
     {
-        SIMULATION_LOOP_SCOPE
-
-        // Keep running
-        runStep();
         sofa::type::vector<std::pair<GLFWwindow*, SofaGLFWWindow*>> closedWindows;
         
         for (auto& [glfwWindow, sofaGlfwWindow] : s_mapWindows)
@@ -615,19 +614,6 @@ void SofaGLFWBaseGUI::initVisual()
     }
     
     setWindowBackgroundImage("textures/SOFA_logo.bmp", 0);
-}
-
-void SofaGLFWBaseGUI::runStep()
-{
-    if(simulationIsRunning())
-    {
-        helper::AdvancedTimer::begin("Animate");
-
-        node::animate(this->groot.get(), this->groot->getDt());
-        node::updateVisual(this->groot.get());
-
-        helper::AdvancedTimer::end("Animate");
-    }
 }
 
 void SofaGLFWBaseGUI::terminate()

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.cpp
@@ -193,6 +193,13 @@ void SofaGLFWBaseGUI::drawScene()
 
 void SofaGLFWBaseGUI::viewAll()
 {
+    for (auto& w : s_mapWindows)
+    {
+        m_simulationLoop.pushCommand([this, w = w.second]()
+        {
+            w->centerCamera(this->groot, m_vparams);
+        });
+    }
 }
 
 void SofaGLFWBaseGUI::saveView()
@@ -614,7 +621,10 @@ void SofaGLFWBaseGUI::initVisual()
     m_vparams = VisualParams::defaultInstance();
     for (auto& [glfwWindow, sofaGlfwWindow] : s_mapWindows)
     {
-        sofaGlfwWindow->centerCamera(this->groot, m_vparams);
+        m_simulationLoop.pushCommand([this, sofaGlfwWindow]()
+        {
+            sofaGlfwWindow->centerCamera(this->groot, m_vparams);
+        });
     }
     
     setWindowBackgroundImage("textures/SOFA_logo.bmp", 0);
@@ -765,11 +775,17 @@ void SofaGLFWBaseGUI::key_callback(GLFWwindow* window, int key, int scancode, in
             {
                 if (action == GLFW_PRESS)
                 {
-                    currentGUI->getPickHandler()->activateRay(0, 0, rootNode.get());
+                    currentGUI->m_simulationLoop.pushCommand([currentGUI, rootNode]()
+                    {
+                        currentGUI->getPickHandler()->activateRay(0, 0, rootNode.get());
+                    });
                 }
                 else if (action == GLFW_RELEASE)
                 {
-                    currentGUI->getPickHandler()->deactivateRay();
+                    currentGUI->m_simulationLoop.pushCommand([currentGUI]()
+                    {
+                        currentGUI->getPickHandler()->deactivateRay();
+                    });
                 }
             }
             break;
@@ -785,7 +801,10 @@ void SofaGLFWBaseGUI::key_callback(GLFWwindow* window, int key, int scancode, in
             // A: Show scene axis
             case GLFW_KEY_A:
             {
-                triggerSceneAxis(currentGUI->groot);
+                currentGUI->m_simulationLoop.pushCommand([groot = currentGUI->groot]()
+                {
+                    triggerSceneAxis(groot);
+                });
                 break;
             }
             // B: Switch background
@@ -917,7 +936,11 @@ void SofaGLFWBaseGUI::moveRayPickInteractor(int eventX, int eventY)
     position = transform * Vec4d(0, 0, 0, 1);
     direction = transform * Vec4d(0, 0, 1, 0);
     direction.normalize();
-    getPickHandler()->updateRay(position, direction);
+
+    m_simulationLoop.pushCommand([this, position, direction]()
+    {
+        getPickHandler()->updateRay(position, direction);
+    });
 }
 
 void SofaGLFWBaseGUI::window_pos_callback(GLFWwindow* window, int xpos, int ypos)
@@ -1043,7 +1066,7 @@ void SofaGLFWBaseGUI::scroll_callback(GLFWwindow* window, double xoffset, double
     auto currentSofaWindow = s_mapWindows.find(window);
     if (currentSofaWindow != s_mapWindows.end() && currentSofaWindow->second)
     {
-        currentSofaWindow->second->scrollEvent(xoffset, yoffset);
+        currentSofaWindow->second->scrollEvent(xoffset, yoffset, currentGUI->second);
     }
 }
 

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -27,6 +27,7 @@
 
 #include <SofaGLFW/BaseGUIEngine.h>
 #include <SofaGLFW/NullGUIEngine.h>
+#include <SofaGLFW/SimulationLoop.h>
 #include <sofa/gui/common/BaseViewer.h>
 #include <memory>
 
@@ -148,11 +149,12 @@ private:
     static void content_scale_callback(GLFWwindow* window, float xscale, float yscale);
 
     void makeCurrentContext(GLFWwindow* sofaWindow);
-    void runStep();
 
     inline static std::map<GLFWwindow*, SofaGLFWWindow*> s_mapWindows{};
     inline static std::map<GLFWwindow*, SofaGLFWBaseGUI*> s_mapGUIs{};
     inline static std::size_t s_numberOfActiveWindows = 0;
+
+    SimulationLoop m_simulationLoop;
 
     bool m_bGlfwIsInitialized{ false };
     bool m_bGlewIsInitialized{ false };

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -21,18 +21,19 @@
 ******************************************************************************/
 #pragma once
 
-#include <sofa/simulation/Node.h>
-#include <sofa/gl/DrawToolGL.h>
-#include <sofa/component/visual/BaseCamera.h>
-
 #include <SofaGLFW/BaseGUIEngine.h>
 #include <SofaGLFW/NullGUIEngine.h>
 #include <SofaGLFW/SimulationLoop.h>
+#include <SofaGLFW/SofaGLFWMouseManager.h>
+#include <sofa/component/visual/BaseCamera.h>
+#include <sofa/gl/DrawToolGL.h>
+#include <sofa/gl/VideoRecorderFFMPEG.h>
 #include <sofa/gui/common/BaseViewer.h>
+#include <sofa/simulation/Node.h>
+
 #include <memory>
 
-#include <SofaGLFW/SofaGLFWMouseManager.h>
-#include <sofa/gl/VideoRecorderFFMPEG.h>
+#include "SceneSnapshot.h"
 
 struct GLFWwindow;
 struct GLFWmonitor;

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWBaseGUI.h
@@ -120,6 +120,12 @@ public:
     {
         return m_guiEngine;
     }
+
+    SimulationLoop& getSimulationLoop()
+    {
+        return m_simulationLoop;
+    }
+
     void moveRayPickInteractor(int eventX, int eventY) override ;
     
     void toggleVideoRecording();

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -67,7 +67,7 @@ void SofaGLFWWindow::close()
 }
 
 
-void SofaGLFWWindow::draw(simulation::NodeSPtr groot, core::visual::VisualParams* vparams)
+void SofaGLFWWindow::draw(const SceneSnapshot& sceneSnapshot, sofa::helper::visual::DrawTool* drawTool)
 {
     glClearColor(m_backgroundColor.r(), m_backgroundColor.g(), m_backgroundColor.b(), m_backgroundColor.a());
     glClearDepth(1.0);
@@ -86,16 +86,18 @@ void SofaGLFWWindow::draw(simulation::NodeSPtr groot, core::visual::VisualParams
         msg_error("SofaGLFWGUI") << "No camera defined.";
         return;
     }
+
+    int width, height;
+    glfwGetFramebufferSize(m_glfwWindow, &width, &height);
     
-    
-    if (groot->f_bbox.getValue().isValid())
-    {        
-        vparams->sceneBBox() = groot->f_bbox.getValue();
-        m_currentCamera->setBoundingBox(vparams->sceneBBox().minBBox(), vparams->sceneBBox().maxBBox());
-    }
-    m_currentCamera->computeZ();
-    m_currentCamera->d_widthViewport.setValue(vparams->viewport()[2]);
-    m_currentCamera->d_heightViewport.setValue(vparams->viewport()[3]);
+    // if (groot->f_bbox.getValue().isValid())
+    // {
+    //     vparams->sceneBBox() = groot->f_bbox.getValue();
+    //     m_currentCamera->setBoundingBox(vparams->sceneBBox().minBBox(), vparams->sceneBBox().maxBBox());
+    // }
+    // m_currentCamera->computeZ();
+    // m_currentCamera->d_widthViewport.setValue(vparams->viewport()[2]);
+    // m_currentCamera->d_heightViewport.setValue(vparams->viewport()[3]);
 
     // matrices
     double lastModelviewMatrix [16];
@@ -104,7 +106,7 @@ void SofaGLFWWindow::draw(simulation::NodeSPtr groot, core::visual::VisualParams
     m_currentCamera->getOpenGLProjectionMatrix(lastProjectionMatrix);
     m_currentCamera->getOpenGLModelViewMatrix(lastModelviewMatrix);
 
-    glViewport(0, 0, vparams->viewport()[2], vparams->viewport()[3]);
+    glViewport(0, 0, width, height);
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
     glMultMatrixd(lastProjectionMatrix);
@@ -114,13 +116,13 @@ void SofaGLFWWindow::draw(simulation::NodeSPtr groot, core::visual::VisualParams
     glMultMatrixd(lastModelviewMatrix);
 
     // Update the visual params
-    vparams->zNear() = m_currentCamera->getZNear();
-    vparams->zFar() = m_currentCamera->getZFar();
-    vparams->setProjectionMatrix(lastProjectionMatrix);
-    vparams->setModelViewMatrix(lastModelviewMatrix);
+    // vparams->zNear() = m_currentCamera->getZNear();
+    // vparams->zFar() = m_currentCamera->getZFar();
+    // vparams->setProjectionMatrix(lastProjectionMatrix);
+    // vparams->setModelViewMatrix(lastModelviewMatrix);
 
-    simulation::node::draw(vparams, groot.get());
-    
+    // simulation::node::draw(vparams, groot.get());
+    sceneSnapshot.draw(drawTool);
 }
 
 void SofaGLFWWindow::setBackgroundColor(const RGBAColor& newColor)

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -90,14 +90,14 @@ void SofaGLFWWindow::draw(const SceneSnapshot& sceneSnapshot, sofa::helper::visu
     int width, height;
     glfwGetFramebufferSize(m_glfwWindow, &width, &height);
     
-    // if (groot->f_bbox.getValue().isValid())
-    // {
-    //     vparams->sceneBBox() = groot->f_bbox.getValue();
-    //     m_currentCamera->setBoundingBox(vparams->sceneBBox().minBBox(), vparams->sceneBBox().maxBBox());
-    // }
-    // m_currentCamera->computeZ();
-    // m_currentCamera->d_widthViewport.setValue(vparams->viewport()[2]);
-    // m_currentCamera->d_heightViewport.setValue(vparams->viewport()[3]);
+    if (sceneSnapshot.m_bbox.isValid())
+    {
+        // vparams->sceneBBox() = sceneSnapshot.m_bbox;
+        m_currentCamera->setBoundingBox(sceneSnapshot.m_bbox.minBBox(), sceneSnapshot.m_bbox.maxBBox());
+    }
+    m_currentCamera->computeZ();
+    m_currentCamera->d_widthViewport.setValue(width);
+    m_currentCamera->d_heightViewport.setValue(height);
 
     // matrices
     double lastModelviewMatrix [16];
@@ -121,7 +121,6 @@ void SofaGLFWWindow::draw(const SceneSnapshot& sceneSnapshot, sofa::helper::visu
     // vparams->setProjectionMatrix(lastProjectionMatrix);
     // vparams->setModelViewMatrix(lastModelviewMatrix);
 
-    // simulation::node::draw(vparams, groot.get());
     sceneSnapshot.draw(drawTool);
 }
 

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -227,45 +227,48 @@ void SofaGLFWWindow::alignCamera(sofaglfw::SofaGLFWBaseGUI* baseGUI, const Camer
 {
     if (baseGUI)
     {
-        sofa::core::sptr<sofa::simulation::Node> groot = baseGUI->getRootNode();
-        if (groot)
+        baseGUI->getSimulationLoop().pushCommand([baseGUI, align]()
         {
-            sofa::component::visual::BaseCamera::SPtr camera;
-            groot->get(camera);
-
-            if (camera)
+            sofa::core::sptr<sofa::simulation::Node> groot = baseGUI->getRootNode();
+            if (groot)
             {
-                sofa::type::Quat<float> orientation;
+                sofa::component::visual::BaseCamera::SPtr camera;
+                groot->get(camera);
 
-                switch (align)
+                if (camera)
                 {
-                case CameraAlignement::TOP:
-                    orientation = sofa::type::Quat(-0.707f, 0.f, 0.f, 0.707f);
-                    break;
-                case CameraAlignement::BOTTOM:
-                    orientation = sofa::type::Quat(0.707f, 0.f, 0.f, 0.707f);
-                    break;
-                case CameraAlignement::FRONT:
-                    orientation = sofa::type::Quat(0.f, 0.f, 0.f, 1.f);
-                    break;
-                case CameraAlignement::BACK:
-                    orientation = sofa::type::Quat(0.f, 1.f, 0.f, 0.f);
-                    break;
-                case CameraAlignement::LEFT:
-                    orientation = sofa::type::Quat(0.f, 0.707f, 0.f, 0.707f);
-                    break;
-                case CameraAlignement::RIGHT:
-                    orientation = sofa::type::Quat(0.f, -0.707f, 0.f, 0.707f);
-                    break;
-                }
+                    sofa::type::Quat<float> orientation;
 
-                auto bbCenter = (groot->f_bbox.getValue().maxBBox() + groot->f_bbox.getValue().minBBox()) * 0.5f;
-                const auto cameraPosition = camera->getPositionFromOrientation(sofa::type::Vec3(0., 0., 0.), -camera->getDistance(), orientation);
-                camera->setView(cameraPosition + bbCenter, orientation);
-                camera->d_lookAt.setValue(bbCenter);
-                camera->setCameraType(sofa::core::visual::VisualParams::ORTHOGRAPHIC_TYPE);
+                    switch (align)
+                    {
+                    case CameraAlignement::TOP:
+                        orientation = sofa::type::Quat(-0.707f, 0.f, 0.f, 0.707f);
+                        break;
+                    case CameraAlignement::BOTTOM:
+                        orientation = sofa::type::Quat(0.707f, 0.f, 0.f, 0.707f);
+                        break;
+                    case CameraAlignement::FRONT:
+                        orientation = sofa::type::Quat(0.f, 0.f, 0.f, 1.f);
+                        break;
+                    case CameraAlignement::BACK:
+                        orientation = sofa::type::Quat(0.f, 1.f, 0.f, 0.f);
+                        break;
+                    case CameraAlignement::LEFT:
+                        orientation = sofa::type::Quat(0.f, 0.707f, 0.f, 0.707f);
+                        break;
+                    case CameraAlignement::RIGHT:
+                        orientation = sofa::type::Quat(0.f, -0.707f, 0.f, 0.707f);
+                        break;
+                    }
+
+                    auto bbCenter = (groot->f_bbox.getValue().maxBBox() + groot->f_bbox.getValue().minBBox()) * 0.5f;
+                    const auto cameraPosition = camera->getPositionFromOrientation(sofa::type::Vec3(0., 0., 0.), -camera->getDistance(), orientation);
+                    camera->setView(cameraPosition + bbCenter, orientation);
+                    camera->d_lookAt.setValue(bbCenter);
+                    camera->setCameraType(sofa::core::visual::VisualParams::ORTHOGRAPHIC_TYPE);
+                }
             }
-        }
+        });
     }
 }
 
@@ -303,54 +306,58 @@ void SofaGLFWWindow::mouseMoveEvent(int xpos, int ypos, SofaGLFWBaseGUI* gui)
     {
         case GLFW_PRESS:
         {
-            core::objectmodel::MouseEvent* mEvent = nullptr;
-            if (m_currentButton == GLFW_MOUSE_BUTTON_LEFT)
-                mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::LeftPressed, xpos, ypos);
-            else if (m_currentButton == GLFW_MOUSE_BUTTON_RIGHT)
-                mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::RightPressed, xpos, ypos);
-            else if (m_currentButton == GLFW_MOUSE_BUTTON_MIDDLE)
-                mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::MiddlePressed, xpos, ypos);
-            else
+            gui->getSimulationLoop().pushCommand([camera = m_currentCamera, rootNode = gui->getRootNode(), xpos, ypos, button = m_currentButton]()
             {
-                // A fallback event to rule them all...
-                mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::AnyExtraButtonPressed, xpos, ypos);
-            }
-            m_currentCamera->manageEvent(mEvent);
-
-            auto rootNode = gui->getRootNode();
-
-            rootNode->propagateEvent(core::execparams::defaultInstance(), mEvent);
-            delete mEvent;
+                core::objectmodel::MouseEvent* mEvent = nullptr;
+                if (button == GLFW_MOUSE_BUTTON_LEFT)
+                    mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::LeftPressed, xpos, ypos);
+                else if (button == GLFW_MOUSE_BUTTON_RIGHT)
+                    mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::RightPressed, xpos, ypos);
+                else if (button == GLFW_MOUSE_BUTTON_MIDDLE)
+                    mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::MiddlePressed, xpos, ypos);
+                else
+                {
+                    // A fallback event to rule them all...
+                    mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::AnyExtraButtonPressed, xpos, ypos);
+                }
+                camera->manageEvent(mEvent);
+                rootNode->propagateEvent(core::execparams::defaultInstance(), mEvent);
+                delete mEvent;
+            });
 
             break;
         }
         case GLFW_RELEASE:
         {
-            core::objectmodel::MouseEvent* mEvent = nullptr;
-            if (m_currentButton == GLFW_MOUSE_BUTTON_LEFT)
-                mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::LeftReleased, xpos, ypos);
-            else if (m_currentButton == GLFW_MOUSE_BUTTON_RIGHT)
-                mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::RightReleased, xpos, ypos);
-            else if (m_currentButton == GLFW_MOUSE_BUTTON_MIDDLE)
-                mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::MiddleReleased, xpos, ypos);
-            else
+            gui->getSimulationLoop().pushCommand([camera = m_currentCamera, rootNode = gui->getRootNode(), xpos, ypos, button = m_currentButton]()
             {
-                // A fallback event to rules them all...
-                mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::AnyExtraButtonReleased, xpos, ypos);
-            }
-            m_currentCamera->manageEvent(mEvent);
-
-            auto rootNode = gui->getRootNode();
-
-            rootNode->propagateEvent(core::execparams::defaultInstance(), mEvent);
-            delete mEvent;
+                core::objectmodel::MouseEvent* mEvent = nullptr;
+                if (button == GLFW_MOUSE_BUTTON_LEFT)
+                    mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::LeftReleased, xpos, ypos);
+                else if (button == GLFW_MOUSE_BUTTON_RIGHT)
+                    mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::RightReleased, xpos, ypos);
+                else if (button == GLFW_MOUSE_BUTTON_MIDDLE)
+                    mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::MiddleReleased, xpos, ypos);
+                else
+                {
+                    // A fallback event to rules them all...
+                    mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::AnyExtraButtonReleased, xpos, ypos);
+                }
+                camera->manageEvent(mEvent);
+                rootNode->propagateEvent(core::execparams::defaultInstance(), mEvent);
+                delete mEvent;
+            });
 
             break;
         }
         default:
         {
-            core::objectmodel::MouseEvent me(core::objectmodel::MouseEvent::Move, xpos, ypos);
-            m_currentCamera->manageEvent(&me);
+            gui->getSimulationLoop().pushCommand([camera = m_currentCamera, rootNode = gui->getRootNode(), xpos, ypos]()
+            {
+                core::objectmodel::MouseEvent mEvent(core::objectmodel::MouseEvent::Move, xpos, ypos);
+                camera->manageEvent(&mEvent);
+                rootNode->propagateEvent(core::execparams::defaultInstance(), &mEvent);
+            });
             break;
         }
     }
@@ -383,29 +390,29 @@ bool SofaGLFWWindow::mouseEvent(GLFWwindow* window, int width, int height,int bu
     mousepos.y = static_cast<int>(ypos);
     auto rootNode = gui->getRootNode();
 
-    if (GLFW_MOD_SHIFT)
+    gui->getSimulationLoop().pushCommand([gui, width, height, rootNode, button, action, mousepos, xpos, ypos]()
     {
-        gui->getPickHandler()->activateRay(width, height, rootNode.get());
-        gui->getPickHandler()->updateMouse2D(mousepos);
+        if (GLFW_MOD_SHIFT)
+        {
+            gui->getPickHandler()->activateRay(width, height, rootNode.get());
+            gui->getPickHandler()->updateMouse2D(mousepos);
 
-        if (action == GLFW_PRESS)
-        {
-            if (button == GLFW_MOUSE_BUTTON_LEFT)
+            if (action == GLFW_PRESS)
             {
-                gui->getPickHandler()->handleMouseEvent(PRESSED, LEFT);
+                if (button == GLFW_MOUSE_BUTTON_LEFT)
+                {
+                    gui->getPickHandler()->handleMouseEvent(PRESSED, LEFT);
+                }
+                else if (button == GLFW_MOUSE_BUTTON_RIGHT)
+                {
+                    gui->getPickHandler()->handleMouseEvent(PRESSED, RIGHT);
+                }
+                else if (button == GLFW_MOUSE_BUTTON_MIDDLE)
+                {
+                    gui->getPickHandler()->handleMouseEvent(PRESSED, MIDDLE);
+                }
             }
-            else if (button == GLFW_MOUSE_BUTTON_RIGHT)
-            {
-                gui->getPickHandler()->handleMouseEvent(PRESSED, RIGHT);
-            }
-            else if (button == GLFW_MOUSE_BUTTON_MIDDLE)
-            {
-                gui->getPickHandler()->handleMouseEvent(PRESSED, MIDDLE);
-            }
-        }
-        else if (action == GLFW_RELEASE)
-        {
-            if (action == GLFW_RELEASE)
+            else if (action == GLFW_RELEASE)
             {
                 if (button == GLFW_MOUSE_BUTTON_LEFT)
                 {
@@ -421,22 +428,29 @@ bool SofaGLFWWindow::mouseEvent(GLFWwindow* window, int width, int height,int bu
                     gui->getPickHandler()->handleMouseEvent(RELEASED, MIDDLE);
                 }
             }
+            gui->moveRayPickInteractor(static_cast<int>(xpos), static_cast<int>(ypos));
         }
-        gui->moveRayPickInteractor(xpos, ypos);
-    }
-    else
-    {
-        gui->getPickHandler()->activateRay(width, height, rootNode.get());
-    }
+        else
+        {
+            gui->getPickHandler()->activateRay(width, height, rootNode.get());
+        }
+    });
+
     return true;
 }
 
-void SofaGLFWWindow::scrollEvent(double xoffset, double yoffset)
+void SofaGLFWWindow::scrollEvent(double xoffset, double yoffset, SofaGLFWBaseGUI* gui)
 {
     SOFA_UNUSED(xoffset);
-    const double yFactor = 10.f;
-    core::objectmodel::MouseEvent me(core::objectmodel::MouseEvent::Wheel, static_cast<int>(yoffset * yFactor));
-    m_currentCamera->manageEvent(&me);
+    if (gui && m_currentCamera)
+    {
+        const double yFactor = 10.f;
+        gui->getSimulationLoop().pushCommand([camera = m_currentCamera, yoffset, yFactor]()
+        {
+            core::objectmodel::MouseEvent me(core::objectmodel::MouseEvent::Wheel, static_cast<int>(yoffset * yFactor));
+            camera->manageEvent(&me);
+        });
+    }
 }
 
 } // namespace sofaglfw

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.cpp
@@ -306,58 +306,61 @@ void SofaGLFWWindow::mouseMoveEvent(int xpos, int ypos, SofaGLFWBaseGUI* gui)
     {
         case GLFW_PRESS:
         {
-            gui->getSimulationLoop().pushCommand([camera = m_currentCamera, rootNode = gui->getRootNode(), xpos, ypos, button = m_currentButton]()
+            // gui->getSimulationLoop().pushCommand([camera = m_currentCamera, rootNode = gui->getRootNode(), xpos, ypos, button = m_currentButton]()
             {
                 core::objectmodel::MouseEvent* mEvent = nullptr;
-                if (button == GLFW_MOUSE_BUTTON_LEFT)
+                if (m_currentButton == GLFW_MOUSE_BUTTON_LEFT)
                     mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::LeftPressed, xpos, ypos);
-                else if (button == GLFW_MOUSE_BUTTON_RIGHT)
+                else if (m_currentButton == GLFW_MOUSE_BUTTON_RIGHT)
                     mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::RightPressed, xpos, ypos);
-                else if (button == GLFW_MOUSE_BUTTON_MIDDLE)
+                else if (m_currentButton == GLFW_MOUSE_BUTTON_MIDDLE)
                     mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::MiddlePressed, xpos, ypos);
                 else
                 {
                     // A fallback event to rule them all...
                     mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::AnyExtraButtonPressed, xpos, ypos);
                 }
-                camera->manageEvent(mEvent);
-                rootNode->propagateEvent(core::execparams::defaultInstance(), mEvent);
+                m_currentCamera->manageEvent(mEvent);
+                gui->getRootNode()->propagateEvent(core::execparams::defaultInstance(), mEvent);
                 delete mEvent;
-            });
+            }
+            // });
 
             break;
         }
         case GLFW_RELEASE:
         {
-            gui->getSimulationLoop().pushCommand([camera = m_currentCamera, rootNode = gui->getRootNode(), xpos, ypos, button = m_currentButton]()
+            // gui->getSimulationLoop().pushCommand([camera = m_currentCamera, rootNode = gui->getRootNode(), xpos, ypos, button = m_currentButton]()
             {
                 core::objectmodel::MouseEvent* mEvent = nullptr;
-                if (button == GLFW_MOUSE_BUTTON_LEFT)
+                if (m_currentButton == GLFW_MOUSE_BUTTON_LEFT)
                     mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::LeftReleased, xpos, ypos);
-                else if (button == GLFW_MOUSE_BUTTON_RIGHT)
+                else if (m_currentButton == GLFW_MOUSE_BUTTON_RIGHT)
                     mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::RightReleased, xpos, ypos);
-                else if (button == GLFW_MOUSE_BUTTON_MIDDLE)
+                else if (m_currentButton == GLFW_MOUSE_BUTTON_MIDDLE)
                     mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::MiddleReleased, xpos, ypos);
                 else
                 {
                     // A fallback event to rules them all...
                     mEvent = new core::objectmodel::MouseEvent(core::objectmodel::MouseEvent::AnyExtraButtonReleased, xpos, ypos);
                 }
-                camera->manageEvent(mEvent);
-                rootNode->propagateEvent(core::execparams::defaultInstance(), mEvent);
+                m_currentCamera->manageEvent(mEvent);
+                gui->getRootNode()->propagateEvent(core::execparams::defaultInstance(), mEvent);
                 delete mEvent;
-            });
+            }
+            // });
 
             break;
         }
         default:
         {
-            gui->getSimulationLoop().pushCommand([camera = m_currentCamera, rootNode = gui->getRootNode(), xpos, ypos]()
+            // gui->getSimulationLoop().pushCommand([camera = m_currentCamera, rootNode = gui->getRootNode(), xpos, ypos]()
             {
                 core::objectmodel::MouseEvent mEvent(core::objectmodel::MouseEvent::Move, xpos, ypos);
-                camera->manageEvent(&mEvent);
-                rootNode->propagateEvent(core::execparams::defaultInstance(), &mEvent);
-            });
+                m_currentCamera->manageEvent(&mEvent);
+                gui->getRootNode()->propagateEvent(core::execparams::defaultInstance(), &mEvent);
+            }
+            // });
             break;
         }
     }

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
@@ -47,7 +47,7 @@ public:
     SofaGLFWWindow(GLFWwindow* glfwWindow, sofa::component::visual::BaseCamera::SPtr camera);
     virtual ~SofaGLFWWindow() = default;
 
-    void draw(sofa::simulation::NodeSPtr groot, sofa::core::visual::VisualParams* vparams);
+    void draw(const SceneSnapshot& sceneSnapshot, sofa::helper::visual::DrawTool* drawTool);
     void close();
 
     void mouseMoveEvent(int xpos, int ypos,SofaGLFWBaseGUI* gui);

--- a/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
+++ b/SofaGLFW/src/SofaGLFW/SofaGLFWWindow.h
@@ -52,7 +52,7 @@ public:
 
     void mouseMoveEvent(int xpos, int ypos,SofaGLFWBaseGUI* gui);
     void mouseButtonEvent(int button, int action, int mods);
-    void scrollEvent(double xoffset, double yoffset);
+    void scrollEvent(double xoffset, double yoffset, SofaGLFWBaseGUI* gui);
     void setBackgroundColor(const RGBAColor& newColor);
     void setBackgroundImage(const std::string& filename);
     void drawBackgroundImage();

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.cpp
@@ -640,9 +640,28 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
         const auto posX = ImGui::GetCursorPosX();
         if (showFPSInMenuBar)
         {
+            float framerateValue = io.Framerate;
+            if (m_framerateType == 1)
+            {
+                framerateValue = baseGUI->getSimulationLoop().getPhysicsFramerate();
+            }
+
             ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ImGui::GetColumnWidth() - ImGui::CalcTextSize("1000.0 FPS ").x
-                 - 2 * ImGui::GetStyle().ItemSpacing.x);
-            ImGui::Text("%.1f FPS", io.Framerate);
+                 - 2 * ImGui::GetStyle().ItemSpacing.x - ImGui::CalcTextSize(ICON_FA_CARET_DOWN).x - 2 * ImGui::GetStyle().ItemSpacing.x);
+
+            ImGui::Text("%.1f FPS", framerateValue);
+            ImGui::SameLine();
+            if (ImGui::Button(ICON_FA_CARET_DOWN))
+            {
+                ImGui::OpenPopup("FramerateTypePopup");
+            }
+
+            if (ImGui::BeginPopup("FramerateTypePopup"))
+            {
+                if (ImGui::Selectable("Visualization", m_framerateType == 0)) m_framerateType = 0;
+                if (ImGui::Selectable("Physics", m_framerateType == 1)) m_framerateType = 1;
+                ImGui::EndPopup();
+            }
             ImGui::SetCursorPosX(posX);
         }
         if (showTime)
@@ -650,7 +669,7 @@ void ImGuiGUIEngine::startFrame(sofaglfw::SofaGLFWBaseGUI* baseGUI)
             auto position = ImGui::GetCursorPosX() + ImGui::GetColumnWidth() - ImGui::CalcTextSize("Time: 000.000  ").x
                 - 2 * ImGui::GetStyle().ItemSpacing.x;
             if (showFPSInMenuBar)
-                position -= ImGui::CalcTextSize("1000.0 FPS ").x;
+                position -= ImGui::CalcTextSize("1000.0 FPS ").x + 2 * ImGui::GetStyle().ItemSpacing.x + ImGui::CalcTextSize(ICON_FA_CARET_DOWN).x + 2 * ImGui::GetStyle().ItemSpacing.x;
             ImGui::SetCursorPosX(position);
             ImGui::Text("Time: %.3f", groot->getTime());
             ImGui::SetCursorPosX(posX);

--- a/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
+++ b/SofaImGui/src/SofaImGui/ImGuiGUIEngine.h
@@ -114,6 +114,7 @@ protected:
     unsigned long m_screenshotCounter{0};
     bool m_isTerminated{ false };
     std::size_t m_frameCount{0};
+    int m_framerateType{ 0 }; // 0: Visualization, 1: Physics
     static inline constexpr int s_NB_PBOS = 2;
     GLuint m_pbos[s_NB_PBOS];
     sofa::type::Vec2i m_pboSize;


### PR DESCRIPTION
Rendering and simulation loops run asynchronously. This allows different update frequencies. The rendering loop enables VSync, such that it runs at the frequency of the monitor (in my case 60 Hz), while the simulation loops runs as fast as possible.

The rendering and GUI is always responsive, even for slow simulations, running much slower than the rendering frequency. On the opposite, if the simulation is much faster, the rendering loop always runs at the frequency of the monitor, limiting the accesses to GPU resources.

Until now, the rendering and simulation loops were run sequentially. With the asynchronicity, the accesses to the scene graph and SOFA data structures becomes thread-unsafe. To allow to keep rendering a mesh responsively, the scene to be rendered is captured at every simulation tick. The rendering loop always renders the latest snapshot.

To do:

- [ ] Capture the camera properties to remove all the camera accesses in the rendering loop
- [ ] Investigate `VisualParams` thread-safety
- [x] Implement a command queue for the GUI
- [ ] Capture all the displayed Data in the GUI
- [ ] Deal with Visual models
- [ ] Deal with `OglSceneFrame`
- [ ] Capture `DrawTool` features (lighting, blending etc)
- [x] Show the physics frequency in imgui
- [ ] Deal with the video recorder
- [ ] Indication that the simulation is running after a given timeout
- [ ] Interaction with the mouse
- [ ] Crash when using multithreading in SOFA


Example where the sim runs faster than the rendering:


https://github.com/user-attachments/assets/deeb5f40-97b3-4e38-a789-31964f273979


Example where the rendering is faster than the sim:

[sim_slower.webm](https://github.com/user-attachments/assets/3d3fd97a-988a-4909-bd69-807fa367e4a2)

