### PR TITLE
[SofaGLFW, SofaImGui] Fix init calls (and fix import modules from python)

### DIFF
--- a/SofaGLFW/src/SofaGLFW/initSofaGLFW.cpp
+++ b/SofaGLFW/src/SofaGLFW/initSofaGLFW.cpp
@@ -40,7 +40,7 @@ extern "C" {
     SOFAGLFW_API const char* getModuleComponentList();
 }
 
-void initExternalModule()
+void init()
 {
     static bool first = true;
     if (first)
@@ -72,15 +72,9 @@ const char* getModuleDescription()
     return "A GLFW Gui for SOFA.";
 }
 
-const char* getModuleComponentList()
+void initExternalModule()
 {
-    //no Components in this plugin
-    return "";
-}
-
-void init()
-{
-    initExternalModule();
+    init();
 }
 
 } // namespace sofaglfw

--- a/SofaImGui/src/SofaImGui/initSofaImGui.cpp
+++ b/SofaImGui/src/SofaImGui/initSofaImGui.cpp
@@ -38,7 +38,7 @@ extern "C" {
     SOFAIMGUI_API const char* getModuleComponentList();
 }
 
-void initExternalModule()
+void init()
 {
     static bool first = true;
     if (first)
@@ -72,15 +72,9 @@ const char* getModuleDescription()
     return "A ImGui Gui for SOFA.";
 }
 
-const char* getModuleComponentList()
+void initExternalModule()
 {
-    //no Components in this plugin
-    return "";
-}
-
-void init()
-{
-    initExternalModule();
+    init();
 }
 
 } // namespace sofaimgui


### PR DESCRIPTION
Had a problem to import SofaImGui in a python script (called directly from python)
It appeared that there was collisions because of the unmangled stuff.
Longer explanation by Claude
```
The cause: ELF symbol interposition on initExternalModule

initExternalModule is declared extern "C" with default visibility, so it lands in the dynamic symbol table as the plain, unmangled name initExternalModule. Every SOFA plugin does the same thing — 109 libraries in your build export that identical symbol:

$ nm -D --defined-only lib*.so | grep -w initExternalModule   # → 109 hits

Because the caller and callee are in the same shared library but the symbol is global and preemptible, GCC does not bind the call locally. It routes it through the PLT:

0000000000265750 <sofaimgui::init()>:
  ...
  2657a7:  call   1a0f50 <initExternalModule@plt>     ← interposable

At load time, that PLT slot gets filled with whatever initExternalModule is first in the global lookup scope — which is the earliest-loaded plugin, not SofaImGui itself. LD_DEBUG=bindings shows it directly:

binding file libSofaGLFW.so.26.12.99 [0] to libSofaCarving.so [0]: normal symbol `initExternalModule'
binding file libSofaImGui.so.26.12.99 [0] to libSofaCarving.so [0]: normal symbol `initExternalModule'
```

All the other plugins do this way actually.